### PR TITLE
PoC / Paraview integration for mesh_doctor 

### DIFF
--- a/geosx_mesh_doctor/mesh_doctor-pvplugin.py
+++ b/geosx_mesh_doctor/mesh_doctor-pvplugin.py
@@ -1,0 +1,60 @@
+from paraview.util.vtkAlgorithm import *
+from paraview.selection import *
+from checks import element_volumes
+
+
+@smproxy.filter(name="Mesh Doctor(GEOS)")
+@smproperty.input(name="Input")
+@smdomain.datatype(dataTypes=["vtkUnstructuredGrid"], composite_data_supported=False)
+class ElementVolumesFilter(VTKPythonAlgorithmBase):
+    """
+        Example portage meshDoctor in PV Python plugins
+    """
+    def __init__(self):
+        super().__init__(outputType='vtkUnstructuredGrid')
+        self.opt = element_volumes.Options(0)
+
+    def RequestData(self, request, inInfo, outInfo):
+        inData = self.GetInputData(inInfo, 0, 0)
+        outData = self.GetOutputData(outInfo, 0)
+        assert inData is not None
+        if outData is None or (not outData.IsA(inData.GetClassName())):
+            outData = inData.NewInstance()
+        extracted = self._Process(inData)
+        outData.DeepCopy( extracted.GetOutput() )
+        outInfo.GetInformationObject(0).Set(outData.DATA_OBJECT(), extracted.GetOutput())
+
+        print("1> There are {} cells under {} m3 vol".format(outData.GetNumberOfCells(), self.opt))
+        return 1
+
+    def _Process(self,mesh):
+        from paraview.vtk import vtkIdTypeArray, vtkSelectionNode, vtkSelection, vtkCollection
+        from vtk import vtkExtractSelection
+        res = element_volumes.check(mesh, self.opt)
+        ids = vtkIdTypeArray()
+        ids.SetNumberOfComponents(1)
+        for val in res.element_volumes:
+            ids.InsertNextValue(val[0])
+
+
+        selectionNode = vtkSelectionNode()
+        selectionNode.SetFieldType(vtkSelectionNode.CELL)
+        selectionNode.SetContentType(vtkSelectionNode.INDICES)
+        selectionNode.SetSelectionList(ids)
+        selection = vtkSelection()
+        selection.AddNode(selectionNode)
+
+        extracted = vtkExtractSelection()
+        extracted.SetInputDataObject(0, mesh)
+        extracted.SetInputData(1, selection)
+        extracted.Update()
+        print("There are {} cells under {} m3 vol".format(extracted.GetOutput().GetNumberOfCells(), self.opt))
+        print("There are {} arrays of cell data".format(extracted.GetOutput().GetCellData().GetNumberOfArrays(), self.opt))
+
+        return extracted
+
+    @smproperty.doublevector(name="Vol Threshold", default_values=["0.0"])
+    def SetValue(self, val):
+        self.opt = element_volumes.Options(val)
+        print("Settings value:", self.opt)
+        self.Modified()


### PR DESCRIPTION
This PR transfer from discussion on GEOS' PR #2790

This is a test to leverage `mesh_doctor` in `Paraview` either as a Python Programmable Filter or a python plugin
A example is given for `element_volumes` check. 
It is run over the unstructured version of _spe11a_ join here.

![screenshot-PVMeshDoctor](https://github.com/GEOS-DEV/GEOS/assets/49998870/f4fab30b-4fa3-4883-8799-7475f7ac5dbe)

[spe11a_mesh_.zip](https://github.com/GEOS-DEV/geosPythonPackages/files/14774801/spe11a_mesh_.zip)

As a programmable filter
-----------------------------------
``mesh_doctor`` has to be deploy in the Paraview python hierarchy so it is able to get the import path

As a python plugin
---------------------------
As exemplified [here](https://gitlab.kitware.com/paraview/paraview/-/tree/master/Examples/Plugins), going through the loading procedure allow load and access to *Mesh Doctor(GEOS)* as a new filter (for now only volume check is available).

Note that as stated in documentation, the test packaged ``mesh_doctor`` version has been modified so that `elementVolumes.check` takes a vtk mesh as input (instead of a file name) as ``Paraview`` is in charge of loading meshes here. This reduce to using the `__check` function included in `elementVolumes`.
