### PR TITLE
Fix import error that would display error in documentation

### DIFF
--- a/geos-mesh/src/geos/mesh/doctor/mesh_doctor.py
+++ b/geos-mesh/src/geos/mesh/doctor/mesh_doctor.py
@@ -9,9 +9,9 @@ except AssertionError as e:
 
 import logging
 
-from geos.mesh.doctor.parsing import CheckHelper
-from geos.mesh.doctor.parsing.cli_parsing import parse_and_set_verbosity
-import geos.mesh.doctor.register as register
+from parsing import CheckHelper
+from parsing.cli_parsing import parse_and_set_verbosity
+import register as register
 
 
 def main():

--- a/geos-mesh/src/geos/mesh/doctor/parsing/collocated_nodes_parsing.py
+++ b/geos-mesh/src/geos/mesh/doctor/parsing/collocated_nodes_parsing.py
@@ -5,7 +5,7 @@ from typing import (
     List,
 )
 
-from geos.mesh.doctor.checks.collocated_nodes import Options, Result
+from checks.collocated_nodes import Options, Result
 
 from . import COLLOCATES_NODES
 

--- a/geos-mesh/src/geos/mesh/doctor/parsing/element_volumes_parsing.py
+++ b/geos-mesh/src/geos/mesh/doctor/parsing/element_volumes_parsing.py
@@ -1,6 +1,6 @@
 import logging
 
-from geos.mesh.doctor.checks.element_volumes import Options, Result
+from checks.element_volumes import Options, Result
 
 from . import ELEMENT_VOLUMES
 

--- a/geos-mesh/src/geos/mesh/doctor/parsing/fix_elements_orderings_parsing.py
+++ b/geos-mesh/src/geos/mesh/doctor/parsing/fix_elements_orderings_parsing.py
@@ -11,7 +11,7 @@ from vtkmodules.vtkCommonDataModel import (
     VTK_WEDGE,
 )
 
-from geos.mesh.doctor.checks.fix_elements_orderings import Options, Result
+from checks.fix_elements_orderings import Options, Result
 
 from . import vtk_output_parsing, FIX_ELEMENTS_ORDERINGS
 

--- a/geos-mesh/src/geos/mesh/doctor/parsing/generate_cube_parsing.py
+++ b/geos-mesh/src/geos/mesh/doctor/parsing/generate_cube_parsing.py
@@ -1,6 +1,6 @@
 import logging
 
-from geos.mesh.doctor.checks.generate_cube import Options, Result, FieldInfo
+from checks.generate_cube import Options, Result, FieldInfo
 
 from . import vtk_output_parsing, generate_global_ids_parsing, GENERATE_CUBE
 from .generate_global_ids_parsing import GlobalIdsInfo

--- a/geos-mesh/src/geos/mesh/doctor/parsing/generate_fractures_parsing.py
+++ b/geos-mesh/src/geos/mesh/doctor/parsing/generate_fractures_parsing.py
@@ -1,6 +1,6 @@
 import logging
 
-from geos.mesh.doctor.checks.generate_fractures import Options, Result, FracturePolicy
+from checks.generate_fractures import Options, Result, FracturePolicy
 
 from . import vtk_output_parsing, GENERATE_FRACTURES
 

--- a/geos-mesh/src/geos/mesh/doctor/parsing/generate_global_ids_parsing.py
+++ b/geos-mesh/src/geos/mesh/doctor/parsing/generate_global_ids_parsing.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 import logging
 
-from geos.mesh.doctor.checks.generate_global_ids import Options, Result
+from checks.generate_global_ids import Options, Result
 
 from . import vtk_output_parsing, GENERATE_GLOBAL_IDS
 

--- a/geos-mesh/src/geos/mesh/doctor/parsing/non_conformal_parsing.py
+++ b/geos-mesh/src/geos/mesh/doctor/parsing/non_conformal_parsing.py
@@ -5,7 +5,7 @@ from typing import (
     List,
 )
 
-from geos.mesh.doctor.checks.non_conformal import Options, Result
+from checks.non_conformal import Options, Result
 
 from . import NON_CONFORMAL
 

--- a/geos-mesh/src/geos/mesh/doctor/parsing/self_intersecting_elements_parsing.py
+++ b/geos-mesh/src/geos/mesh/doctor/parsing/self_intersecting_elements_parsing.py
@@ -2,7 +2,7 @@ import logging
 
 import numpy
 
-from geos.mesh.doctor.checks.self_intersecting_elements import Options, Result
+from checks.self_intersecting_elements import Options, Result
 
 from . import SELF_INTERSECTING_ELEMENTS
 

--- a/geos-mesh/src/geos/mesh/doctor/parsing/supported_elements_parsing.py
+++ b/geos-mesh/src/geos/mesh/doctor/parsing/supported_elements_parsing.py
@@ -1,7 +1,7 @@
 import logging
 import multiprocessing
 
-from geos.mesh.doctor.checks.supported_elements import Options, Result
+from checks.supported_elements import Options, Result
 
 from . import SUPPORTED_ELEMENTS
 

--- a/geos-mesh/src/geos/mesh/doctor/parsing/vtk_output_parsing.py
+++ b/geos-mesh/src/geos/mesh/doctor/parsing/vtk_output_parsing.py
@@ -2,7 +2,7 @@ import os.path
 import logging
 import textwrap
 
-from geos.mesh.doctor.checks.vtk_utils import VtkOutput
+from checks.vtk_utils import VtkOutput
 
 __OUTPUT_FILE = "output"
 __OUTPUT_BINARY_MODE = "data-mode"

--- a/geos-mesh/src/geos/mesh/doctor/register.py
+++ b/geos-mesh/src/geos/mesh/doctor/register.py
@@ -3,20 +3,20 @@ import importlib
 import logging
 from typing import Dict, Callable, Any, Tuple
 
-import geos.mesh.doctor.parsing as parsing
-from geos.mesh.doctor.parsing import CheckHelper, cli_parsing
+import parsing as parsing
+from parsing import CheckHelper, cli_parsing
 
 __HELPERS: Dict[ str, Callable[ [ None ], CheckHelper ] ] = dict()
 __CHECKS: Dict[ str, Callable[ [ None ], Any ] ] = dict()
 
 
 def __load_module_check( module_name: str, check_fct="check" ):
-    module = importlib.import_module( "geos.mesh.doctor.checks." + module_name )
+    module = importlib.import_module( "checks." + module_name )
     return getattr( module, check_fct )
 
 
 def __load_module_check_helper( module_name: str, parsing_fct_suffix="_parsing" ):
-    module = importlib.import_module( "geos.mesh.doctor.parsing." + module_name + parsing_fct_suffix )
+    module = importlib.import_module( "parsing." + module_name + parsing_fct_suffix )
     return CheckHelper( fill_subparser=module.fill_subparser,
                         convert=module.convert,
                         display_results=module.display_results )


### PR DESCRIPTION
Linked with #29 
Correction of module paths when imported in geos-mesh/src/geos/mesh/doctor

Checked all command lines output messages presented in the documentation.
https://geosx-geosx.readthedocs-hosted.com/projects/geosx-geospythonpackages/en/latest/geos-mesh.html

No import errors found anymore.