### PR TITLE
Add char arrays output

### DIFF
--- a/geos-ats/src/geos/ats/helpers/restart_check.py
+++ b/geos-ats/src/geos/ats/helpers/restart_check.py
@@ -460,8 +460,8 @@ class FileComparison( object ):
                 message = "Differing valid characters"
                 message += " (substrings reordering detected):\n" if reordering_detected else ":\n"
 
-                message += f"- {limited_display( maxDisplay, arr_chars_display )}\n"
-                message += f"- {limited_display( maxDisplay, base_arr_chars_display )}\n"
+                message += f"  {limited_display( maxDisplay, arr_chars_display )}\n"
+                message += f"  {limited_display( maxDisplay, base_arr_chars_display )}\n"
                 message += "  " + "".join( ["^" if i in differing_indices else " " for i in range( min( maxDisplay, min_length ) ) ] ) + "\n"
 
         return message

--- a/geos-ats/src/geos/ats/helpers/restart_check.py
+++ b/geos-ats/src/geos/ats/helpers/restart_check.py
@@ -7,6 +7,7 @@ import re
 import argparse
 import logging
 import time
+import string
 from pathlib import Path
 try:
     from geos.ats.helpers.permute_array import permuteArray  # type: ignore[import]
@@ -375,34 +376,82 @@ class FileComparison( object ):
         ARR [in]: The hdf5 Dataset to compare.
         BASE_ARR [in]: The hdf5 Dataset to compare against.
         """
-        # If the shapes are different they can't be compared.
+        message=""
         if arr.shape != base_arr.shape:
-            msg = "Datasets have different shapes and therefore can't be compared: %s, %s.\n" % ( arr.shape,
-                                                                                                  base_arr.shape )
-            self.errorMsg( path, msg, True )
-            return
+            message = "Datasets have different shapes and therefore can't be compared statistically: %s, %s.\n" % (
+                arr.shape, base_arr.shape )
+        else:
+            # Calculate the absolute difference.
+            difference = np.subtract( arr, base_arr )
+            np.abs( difference, out=difference )
 
-        # Create a copy of the arrays.
+            offenders = difference != 0.0
+            n_offenders = np.sum( offenders )
 
-        # Calculate the absolute difference.
-        difference = np.subtract( arr, base_arr )
-        np.abs( difference, out=difference )
+            if n_offenders != 0:
+                max_index = np.unravel_index( np.argmax( difference ), difference.shape )
+                max_difference = difference[ max_index ]
+                offenders_mean = np.mean( difference[ offenders ] )
+                offenders_std = np.std( difference[ offenders ] )
 
-        offenders = difference != 0.0
-        n_offenders = np.sum( offenders )
+                message = "Arrays of types %s and %s have %s values of which %d have differing values.\n" % (
+                    arr.dtype, base_arr.dtype, offenders.size, n_offenders )
+                message += "Statistics of the differences greater than 0:\n"
+                message += "\tmax_index = %s, max = %s, mean = %s, std = %s\n" % (
+                    max_index, max_difference, offenders_mean, offenders_std )
 
-        if n_offenders != 0:
-            max_index = np.unravel_index( np.argmax( difference ), difference.shape )
-            max_difference = difference[ max_index ]
-            offenders_mean = np.mean( difference[ offenders ] )
-            offenders_std = np.std( difference[ offenders ] )
+        # actually, int8 arrays are almost always char arrays, so we sould add a character comparison.
+        if arr.dtype == np.int8 and base_arr.dtype == np.int8:
+            message += self.compareCharArrays( arr, base_arr )
 
-            message = "Arrays of types %s and %s have %s values of which %d have differing values.\n" % (
-                arr.dtype, base_arr.dtype, offenders.size, n_offenders )
-            message += "Statistics of the differences greater than 0:\n"
-            message += "\tmax_index = %s, max = %s, mean = %s, std = %s\n" % ( max_index, max_difference,
-                                                                               offenders_mean, offenders_std )
+        if message != "":
             self.errorMsg( path, message, True )
+
+    def compareCharArrays( self, arr, base_arr ):
+        """
+        Compare the valid characters of two arrays and return a formatted string showing differences.
+
+        ARR [in]: The hdf5 Dataset to compare.
+        BASE_ARR [in]: The hdf5 Dataset to compare against.
+
+        Returns a formatted string highlighting the differing characters.
+        """
+        arr_np = np.array( arr )
+        base_arr_np = np.array( base_arr )
+
+        # Replace invalid characters by line breaks (unused character in the xml inputs)
+        valid_chars = set( string.ascii_letters + string.digits + string.punctuation )
+        arr_chars = "".join([chr(x) if ( 0 <= x < 128 and chr(x) in valid_chars ) else "\n" for x in arr_np.flatten()])
+        base_arr_chars = "".join([chr(x) if ( 0 <= x < 128 and chr(x) in valid_chars ) else "\n" for x in base_arr_np.flatten()])
+
+        # Replace sequences of line breaks with a double spaces to show in the error log
+        arr_chars_spaced = re.sub( r"\n+", "  ", arr_chars )
+        base_arr_chars_spaced = re.sub( r"\n+", "  ", base_arr_chars )
+
+        # Trim arrays to the length of the shortest one
+        min_length = min(len(arr_chars_spaced), len(base_arr_chars_spaced))
+        arr_chars_trim = arr_chars_spaced[:min_length]
+        base_arr_chars_trim = base_arr_chars_spaced[:min_length]
+
+        differing_indices = np.where( np.array( list( arr_chars_trim ) ) != np.array( list( base_arr_chars_trim ) ) )[0]
+        if differing_indices.size != 0:
+            # check for reordering
+            arr_set = sorted(set(arr_chars.split("\n")))
+            base_arr_set = sorted(set(base_arr_chars.split("\n")))
+            message = "Differing valid characters"
+            reordering_detected = arr_set == base_arr_set
+            message += (" (substrings reordering detected):\n" if reordering_detected else ":\n")
+
+            def limited_display(n,string):
+                return string[:n] + f"... ({len(string)-n} omitted chars)" if len(string) > n else string
+
+            maxDisplay = 110 if reordering_detected else 250
+            message += "  " + limited_display(maxDisplay, arr_chars_spaced) + "\n"
+            message += "  " + limited_display(maxDisplay, base_arr_chars_spaced) + "\n"
+            message += "  " + "".join(["^" if i in differing_indices else " " for i in range(min(maxDisplay,min_length))]) + "\n"
+            return message
+        else:
+            return ""
 
     def compareStringArrays( self, path, arr, base_arr ):
         """

--- a/geos-ats/src/geos/ats/helpers/restart_check.py
+++ b/geos-ats/src/geos/ats/helpers/restart_check.py
@@ -394,11 +394,11 @@ class FileComparison( object ):
                 offenders_mean = np.mean( difference[ offenders ] )
                 offenders_std = np.std( difference[ offenders ] )
 
+                message = "Arrays of types %s and %s have %s values of which %d have differing values.\n" % (
+                    arr.dtype, base_arr.dtype, offenders.size, n_offenders )
+                message += "Statistics of the differences greater than 0:\n"
                 message += "\tmax_index = %s, max = %s, mean = %s, std = %s\n" % ( max_index, max_difference,
                                                                                    offenders_mean, offenders_std )
-                message += "Statistics of the differences greater than 0:\n"
-                message += "\tmax_index = %s, max = %s, mean = %s, std = %s\n" % (
-                    max_index, max_difference, offenders_mean, offenders_std )
 
         # actually, int8 arrays are almost always char arrays, so we sould add a character comparison.
         if arr.dtype == np.int8 and base_arr.dtype == np.int8:
@@ -422,8 +422,10 @@ class FileComparison( object ):
         # Replace invalid characters by group-separator characters ('\x1D')
         valid_chars = set( string.printable )
         invalid_char = '\x1D'
-        comp_str = "".join( [ chr( x ) if ( x >= 0 and chr( x ) in valid_chars ) else invalid_char for x in comp_ndarr ] )
-        base_str = "".join( [ chr( x ) if ( x >= 0 and chr( x ) in valid_chars ) else invalid_char for x in base_ndarr ] )
+        comp_str = "".join(
+            [ chr( x ) if ( x >= 0 and chr( x ) in valid_chars ) else invalid_char for x in comp_ndarr ] )
+        base_str = "".join(
+            [ chr( x ) if ( x >= 0 and chr( x ) in valid_chars ) else invalid_char for x in base_ndarr ] )
 
         # replace whitespaces sequences by only one space (preventing indentation / spacing changes detection)
         whitespace_pattern = r"[ \t\n\r\v\f]+"
@@ -450,8 +452,7 @@ class FileComparison( object ):
             comp_str_trim = comp_str_display[ :min_length ]
             base_str_trim = base_str_display[ :min_length ]
 
-            differing_indices = np.where(
-                np.array( list( comp_str_trim ) ) != np.array( list( base_str_trim ) ) )[ 0 ]
+            differing_indices = np.where( np.array( list( comp_str_trim ) ) != np.array( list( base_str_trim ) ) )[ 0 ]
             if differing_indices.size != 0:
                 # check for reordering
                 arr_set = sorted( set( comp_str.split( invalid_char ) ) )


### PR DESCRIPTION
As `geos::string_array` type output as `int8 array`, we cannot really diagnose changing text data in the integrated tests.
As a temporary solution, I propose to add a character comparison output to the current one.

- The comparison operates on the following characters:
```
!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012456789
```
- To prevent indentation false-positive, all successive whitespaces are merged as one space before comparison.
- Other non-printable characters are ignored and considered as _string separators_, useful to detect if the `string_array` could have been only reordered.

As an exemple, for my PR about extending the `cellBlocks` input (which order the `cellBlock` names alphabetically), we would have this message in the `compositionalMultiphaseFlow/deadoil_3ph_staircase_3d_01` test logs:
```
********************************************************************************
Error: /Problem/domain/MeshBodies/mesh/meshLevels/Level0/ElementRegions/elementRegionsGroup/Channel/cellBlocks/__values__
        Arrays of types int8 and int8 have 148 values of which 11 have differing values.
        Statistics of the differences greater than 0:
                max_index = (99,), max = 2, mean = 1.0909090909090908, std = 0.28747978728803447
********************************************************************************
```
And this is what I propose:
```
********************************************************************************
Error: /Problem/domain/MeshBodies/mesh/meshLevels/Level0/ElementRegions/elementRegionsGroup/Channel/cellBlocks/__values__
        Arrays of types int8 and int8 have 148 values of which 11 have differing values.
        Statistics of the differences greater than 0:
                max_index = (99,), max = 2, mean = 1.0909090909090908, std = 0.28747978728803447
        Differing valid characters (substrings reordering detected):
            cb-1_0_0  cb-0_0_0  cb-0_0_1  cb-0_1_1  cb-0_1_2  cb-1_1_2  cb-1_1_3  cb-1_0_3
            cb-0_0_0  cb-0_0_1  cb-0_1_1  cb-0_1_2  cb-1_0_0  cb-1_0_3  cb-1_1_2  cb-1_1_3
               ^             ^       ^           ^     ^ ^ ^       ^ ^         ^       ^  ********************************************************************************
```
The "substrings reordering detected" note helps the reader to know that the substrings are only reordered.