### PR TITLE
Add module path to sys path for PVplugins

### DIFF
--- a/geos-posp/src/PVplugins/PVAttributeMapping.py
+++ b/geos-posp/src/PVplugins/PVAttributeMapping.py
@@ -12,6 +12,8 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
+
 from paraview.util.vtkAlgorithm import (  # type: ignore[import-not-found]
     VTKPythonAlgorithmBase,
     smdomain,

--- a/geos-posp/src/PVplugins/PVCreateConstantAttributePerRegion.py
+++ b/geos-posp/src/PVplugins/PVCreateConstantAttributePerRegion.py
@@ -15,6 +15,8 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
+
 import vtkmodules.util.numpy_support as vnp
 from paraview.util.vtkAlgorithm import (  # type: ignore[import-not-found]
     VTKPythonAlgorithmBase,

--- a/geos-posp/src/PVplugins/PVExtractMergeBlocksVolume.py
+++ b/geos-posp/src/PVplugins/PVExtractMergeBlocksVolume.py
@@ -16,6 +16,8 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
+
 from paraview.util.vtkAlgorithm import (  # type: ignore[import-not-found]
     VTKPythonAlgorithmBase,
     smdomain,

--- a/geos-posp/src/PVplugins/PVExtractMergeBlocksVolumeSurface.py
+++ b/geos-posp/src/PVplugins/PVExtractMergeBlocksVolumeSurface.py
@@ -16,6 +16,8 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
+
 from paraview.util.vtkAlgorithm import (  # type: ignore[import-not-found]
     VTKPythonAlgorithmBase,
     smdomain,

--- a/geos-posp/src/PVplugins/PVExtractMergeBlocksVolumeSurfaceWell.py
+++ b/geos-posp/src/PVplugins/PVExtractMergeBlocksVolumeSurfaceWell.py
@@ -16,6 +16,8 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
+
 from paraview.util.vtkAlgorithm import (  # type: ignore[import-not-found]
     VTKPythonAlgorithmBase,
     smdomain,

--- a/geos-posp/src/PVplugins/PVExtractMergeBlocksVolumeWell.py
+++ b/geos-posp/src/PVplugins/PVExtractMergeBlocksVolumeWell.py
@@ -23,6 +23,8 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
+
 from geos_posp.filters.GeosBlockExtractor import GeosBlockExtractor
 from geos_posp.filters.GeosBlockMerge import GeosBlockMerge
 from geos_posp.processing.vtkUtils import (

--- a/geos-posp/src/PVplugins/PVGeomechanicsAnalysis.py
+++ b/geos-posp/src/PVplugins/PVGeomechanicsAnalysis.py
@@ -23,6 +23,8 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
+
 from geos.utils.Logger import Logger, getLogger
 from geos.utils.PhysicalConstants import (
     DEFAULT_FRICTION_ANGLE_DEG,

--- a/geos-posp/src/PVplugins/PVGeomechanicsWorkflowVolume.py
+++ b/geos-posp/src/PVplugins/PVGeomechanicsWorkflowVolume.py
@@ -17,6 +17,8 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
+
 from paraview.util.vtkAlgorithm import (  # type: ignore[import-not-found]
     VTKPythonAlgorithmBase,
     smdomain,

--- a/geos-posp/src/PVplugins/PVGeomechanicsWorkflowVolumeSurface.py
+++ b/geos-posp/src/PVplugins/PVGeomechanicsWorkflowVolumeSurface.py
@@ -17,6 +17,7 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
 
 from paraview.util.vtkAlgorithm import (  # type: ignore[import-not-found]
     VTKPythonAlgorithmBase,

--- a/geos-posp/src/PVplugins/PVGeomechanicsWorkflowVolumeSurfaceWell.py
+++ b/geos-posp/src/PVplugins/PVGeomechanicsWorkflowVolumeSurfaceWell.py
@@ -17,6 +17,7 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
 
 from paraview.util.vtkAlgorithm import (  # type: ignore[import-not-found]
     VTKPythonAlgorithmBase,

--- a/geos-posp/src/PVplugins/PVGeomechanicsWorkflowVolumeWell.py
+++ b/geos-posp/src/PVplugins/PVGeomechanicsWorkflowVolumeWell.py
@@ -17,6 +17,8 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
+
 from paraview.util.vtkAlgorithm import (  # type: ignore[import-not-found]
     VTKPythonAlgorithmBase,
     smdomain,

--- a/geos-posp/src/PVplugins/PVGeosLogReader.py
+++ b/geos-posp/src/PVplugins/PVGeosLogReader.py
@@ -17,6 +17,8 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
+
 import vtkmodules.util.numpy_support as vnp
 from paraview.util.vtkAlgorithm import (  # type: ignore[import-not-found]
     VTKPythonAlgorithmBase,

--- a/geos-posp/src/PVplugins/PVMergeBlocksEnhanced.py
+++ b/geos-posp/src/PVplugins/PVMergeBlocksEnhanced.py
@@ -12,6 +12,8 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
+
 from paraview.util.vtkAlgorithm import (  # type: ignore[import-not-found]
     VTKPythonAlgorithmBase,
     smdomain,

--- a/geos-posp/src/PVplugins/PVMohrCirclePlot.py
+++ b/geos-posp/src/PVplugins/PVMohrCirclePlot.py
@@ -32,6 +32,8 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
+
 import geos_posp.visu.mohrCircles.functionsMohrCircle as mcf
 import geos_posp.visu.PVUtils.paraviewTreatments as pvt
 from geos_posp.processing.MohrCircle import MohrCircle

--- a/geos-posp/src/PVplugins/PVPythonViewConfigurator.py
+++ b/geos-posp/src/PVplugins/PVPythonViewConfigurator.py
@@ -14,6 +14,8 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
+
 from paraview.simple import (  # type: ignore[import-not-found]
     GetActiveSource,
     GetActiveView,

--- a/geos-posp/src/PVplugins/PVSurfaceGeomechanics.py
+++ b/geos-posp/src/PVplugins/PVSurfaceGeomechanics.py
@@ -13,6 +13,8 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
+
 from paraview.util.vtkAlgorithm import (  # type: ignore[import-not-found]
     VTKPythonAlgorithmBase,
     smdomain,

--- a/geos-posp/src/PVplugins/PVTransferAttributesVolumeSurface.py
+++ b/geos-posp/src/PVplugins/PVTransferAttributesVolumeSurface.py
@@ -12,6 +12,8 @@ parent_dir_path = os.path.dirname(dir_path)
 if parent_dir_path not in sys.path:
     sys.path.append(parent_dir_path)
 
+import PVplugins #required to update sys path
+
 from paraview.simple import (  # type: ignore[import-not-found]
     FindSource,
     GetActiveSource,

--- a/geos-posp/src/PVplugins/__init__.py
+++ b/geos-posp/src/PVplugins/__init__.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+
+# Add other packages path to sys path
+dir_path = os.path.dirname(os.path.realpath(__file__))
+python_root = '../../..'
+
+python_modules = ( 'geos-posp', 'geos-utils', 'geos-geomechanics' )
+
+for m in python_modules:
+    m_path = os.path.abspath( os.path.join( dir_path, python_root, m, 'src' ) )
+    if m_path not in sys.path:
+        sys.path.insert( 0, m_path)


### PR DESCRIPTION
With the new organization of the repository, module paths are not recognized when loading paraview plugins.

This PR adds modules path to sys, fixing this issue

See #67 