### PR TITLE
ci: Upgrade github actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,7 +34,7 @@ jobs:
           echo "This is not a Pull-Request, skipping"
 
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -43,10 +43,10 @@ jobs:
         package-name: ["geos-ats", "geos-mesh", "geos-posp", "geos-timehistory", "geos-trame", "geos-utils", "geos-xml-tools", "geos-xml-viewer", "hdf5-wrapper", "pygeos-tools"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: mpi4py/setup-mpi@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/typing-check.yml
+++ b/.github/workflows/typing-check.yml
@@ -40,4 +40,4 @@ jobs:
     - name: Format and linting check with ruff
       #  working-directory: ./${{ matrix.package-name }}
       run:  |
-        python -m ruff check --config .ruff.toml ./geos-utils
+        python -m ruff check --config .ruff.toml ./${{ matrix.package-name }}

--- a/.github/workflows/typing-check.yml
+++ b/.github/workflows/typing-check.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -19,10 +19,10 @@ jobs:
         package-name: ["geos-geomechanics", "geos-posp", "geos-timehistory", "geos-utils", "geos-xml-tools", "hdf5-wrapper"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: mpi4py/setup-mpi@v1
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.10"
         cache: 'pip'

--- a/geos-geomechanics/src/geos/geomechanics/model/MohrCircle.py
+++ b/geos-geomechanics/src/geos/geomechanics/model/MohrCircle.py
@@ -38,7 +38,6 @@ To use the object:
     p1, p2, p3 :float = mohrCircle.getPrincipalComponents()
     radius :float = mohrCircle.getCircleRadius()
     center :float = mohrCircle.getCircleCenter()
-    
 """
 
 


### PR DESCRIPTION
This PR upgrades the github actions in CI workflows as they became deprecated (https://github.com/actions/runner-images/issues/11101).

actions/checkout@v3 -> actions/checkout@v4
actions/setup-python@v3 -> actions/setup-python@v5