### PR TITLE
chore: Update pyproject.toml to allow for vtk>=9.4

### DIFF
--- a/geos-ats/pyproject.toml
+++ b/geos-ats/pyproject.toml
@@ -39,6 +39,7 @@ setup_ats_environment = "geos.ats.environment_setup:main"
 geos_ats_log_check = "geos.ats.helpers.log_check:main"
 geos_ats_restart_check = "geos.ats.helpers.restart_check:main"
 geos_ats_curve_check = "geos.ats.helpers.curve_check:main"
+geos_ats_process_tests_fails="geos.ats.helpers.process_tests_failures:main"
 
 [project.urls]
 Homepage = "https://github.com/GEOS-DEV/geosPythonPackages"

--- a/geos-mesh/pyproject.toml
+++ b/geos-mesh/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 requires-python = ">=3.10"
 
 dependencies = [
-    "vtk >= 9.4",
+    "vtk >= 9.3",
     "networkx >= 2.4",
     "tqdm >= 4.67",
     "numpy >= 2.2",

--- a/geos-mesh/pyproject.toml
+++ b/geos-mesh/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 requires-python = ">=3.10"
 
 dependencies = [
-    "vtk == 9.3",
+    "vtk >= 9.4",
     "networkx >= 2.4",
     "tqdm >= 4.67",
     "numpy >= 2.2",


### PR DESCRIPTION
The current vtk==9.3 requirement is causing the package to fail. We use 9.4.2 in GEOS.