### PR TITLE
fix: Correct Read The Docs build failures

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,9 +50,8 @@ extensions = [
 ]
 
 autoclass_content = 'both'
-autodoc_mock_imports = [ "ats", "colorcet", "h5py", "lxml", "matplotlib", "meshio", "mpi4py", "numba", "pandas",
-                         "paraview", "pygeosx", "pyevtk", "pylvarray", "scipy", "segyio", "vtk", "xmlschema",
-                         "xmltodict", "xsdata" ]
+autodoc_mock_imports = [ "ats", "colorcet", "meshio", "mpi4py", "numba", "paraview", "pygeosx",
+                         "pyevtk", "pylvarray", "scipy", "segyio", "xmltodict", "xsdata" ]
 autodoc_typehints = 'none'
 autodoc_typehints_format = 'short'
 suppress_warnings = [ "autodoc.mocked_object" ]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
-sphinx >= 8.2
+sphinx < 8.2
 sphinx_rtd_theme >= 3.0
 sphinx-argparse >= 0.5
-sphinx-autodoc-typehints >= 3.1
+sphinx-autodoc-typehints < 3.1
 sphinx-design >= 0.6
 # Running CLI programs and capture outputs
 sphinxcontrib-programoutput >= 0.17
@@ -12,7 +12,7 @@ tqdm >= 4.67
 numpy >= 2.2
 pandas >= 2.2
 typing_extensions > 4.12
-matplotlib>=3.9.4
+matplotlib ~= 3.9.0
 h5py >= 3.12
 lxml >= 4.5.0
 parameterized >= 0.9


### PR DESCRIPTION
Closes #114

This PR aims to correct the failures in the latest Read The Docs builds.
**Specific packages when installing docs/requirements.txt caused conflicts** because the python version used is 3.10.

The first solution was to upgrade to python 3.11 but this would not respect the supported versions 3.10 to 3.12 in the repository.
**The second solution that was applied in this PR is to restrict the version of specific packages.**

PS: A minor cleanup of autodoc_mock_imports was also added but would not have an impact on the resolution of the issue.

Here is the first build that failed after modifying these packages in the following commit https://github.com/GEOS-DEV/geosPythonPackages/commit/de62e294272a6f6aec8e8b6ccabfec9dd8e3e1e0 (see image):

<img width="1307" height="1644" alt="image" src="https://github.com/user-attachments/assets/3cfbb5cf-e4ad-4afc-a7c9-202532e4f618" />
