### PR TITLE
fix: Force mpld3 library version to avoid conflict in geos-trame

### DIFF
--- a/geos-trame/pyproject.toml
+++ b/geos-trame/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "trame-matplotlib==2.0.3",
     "trame-components==2.4.2",
     "trame-gantt==0.1.5",
+    "mpld3<0.5.11",
     "xsdata==24.5",
     "xsdata-pydantic[lxml]==24.5",
     "pyvista==0.45.2",


### PR DESCRIPTION
Closes #117 by restricting the version of mpld3 to be lower than 0.5.11.