### PR TITLE
Jafranc/feat/translate and rotate

### DIFF
--- a/geos-mesh/src/geos/mesh/processing/rotateAndTranslate.py
+++ b/geos-mesh/src/geos/mesh/processing/rotateAndTranslate.py
@@ -1,5 +1,7 @@
 from vtkmodules.numpy_interface import dataset_adapter as dsa
 from vtkmodules.vtkCommonDataModel import vtkUnstructuredGrid
+from vtkmodules.vtkCommonTransforms import vtkTransform
+from vtkmodules.vtkFiltersGeneral import vtkTransformFilter
 from vtkmodules.vtkCommonCore import vtkPoints
 import numpy as np
 import logging
@@ -19,17 +21,26 @@ def transform_mesh( input : vtkUnstructuredGrid, logger : logging.Logger | None 
         logging.basicConfig( level=logging.WARNING )
         logger = logging.getLogger( __name__ )
 
-    translation, rotation, pts = recenter_and_rotate( dsa.numpy_support.vtk_to_numpy(input.GetPoints().GetData()), logger )
+    translation, theta, axis = recenter_and_rotate( dsa.numpy_support.vtk_to_numpy(input.GetPoints().GetData()), logger )
 
-    logger.info(f"Translation {translation}")
-    logger.info(f"Rotation {rotation}")
+    logger.info(f"Theta {theta}")
+    logger.info(f"Axis {axis}")
 
-    output = vtkUnstructuredGrid()
-    (vpts:= vtkPoints()).SetData( dsa.numpy_support.numpy_to_vtk(pts) )
-    output.SetPoints(vpts)
-    output.SetCells(input.GetCellTypesArray(), input.GetCellLocationsArray(), input.GetCells())
+    # output = vtkUnstructuredGrid()
+    # (vpts:= vtkPoints()).SetData( dsa.numpy_support.numpy_to_vtk(pts) )
+    # output.SetPoints(vpts)
+    # output.SetCells(input.GetCellTypesArray(), input.GetCellLocationsArray(), input.GetCells())
 
-    return output
+    transform = vtkTransform()
+    transform.PostMultiply() # we want to apply rotation then translation
+    transform.RotateWXYZ(-theta, axis[0], axis[1], axis[2])
+    transform.Translate(-translation[0], -translation[1], -translation[2])
+    transformFilter = vtkTransformFilter()
+    transformFilter.SetTransform(transform)
+    transformFilter.SetInputData(input)
+    transformFilter.Update()
+
+    return transformFilter.GetOutput()
 
 def local_frame(pts):
     # find 3 orthogonal vectors
@@ -61,7 +72,7 @@ def origin_bounding_box( pts : np.ndarray) -> tuple[np.ndarray, np.ndarray, np.n
 
     return (pts[0], pt0, pt1)
 
-def recenter_and_rotate(pts : np.ndarray, logger : logging.Logger) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+def recenter_and_rotate(pts : np.ndarray, logger : logging.Logger) -> tuple[np.ndarray, float, np.ndarray]:
     """
     Recenter and rotate points to align with principal axes
     
@@ -84,13 +95,20 @@ def recenter_and_rotate(pts : np.ndarray, logger : logging.Logger) -> tuple[np.n
     # find rotation R = U sig V
     rotation = np.asarray([u / np.linalg.norm(u), v / np.linalg.norm(v), w / np.linalg.norm(w)],dtype=np.float64).transpose()
     logger.info(f"R {rotation}")
-    logger.info(f"theta {np.acos(.5 * (np.trace(rotation) - 1)) * 180 / np.pi}")
+
+    theta = np.acos(.5 * (np.trace(rotation) - 1)) * 180 / np.pi
+    logger.info(f"theta {theta}")
+
+    axis = np.asarray([rotation[2, 1] - rotation[1, 2], rotation[0, 2] - rotation[2, 0], rotation[1, 0] - rotation[0, 1]],dtype=np.float64)
+    axis /= np.linalg.norm(axis)
+    logger.info(f"axis {axis}")
 
     pts = (rotation.transpose() @ pts.transpose()).transpose()
     pts[np.abs(pts)<1e-15] = 0. # clipping points too close to zero
     logger.info(f"Un-rotated pts : {pts}")
 
-    return translation, rotation, pts
+    # return translation, rotation, pts
+    return translation, theta, axis
 
 
 # #TO DO : remove

--- a/geos-mesh/src/geos/mesh/processing/rotateAndTranslate.py
+++ b/geos-mesh/src/geos/mesh/processing/rotateAndTranslate.py
@@ -82,11 +82,11 @@ def recenter_and_rotate(pts : np.ndarray, logger : logging.Logger) -> tuple[np.n
     logger.info(f"Local frame u {u}, v {v}, w {w}")
 
     # find rotation R = U sig V
-    rotation = np.matrix([u / np.linalg.norm(u), v / np.linalg.norm(v), w / np.linalg.norm(w)]).transpose()
+    rotation = np.asarray([u / np.linalg.norm(u), v / np.linalg.norm(v), w / np.linalg.norm(w)],dtype=np.float64).transpose()
     logger.info(f"R {rotation}")
     logger.info(f"theta {np.acos(.5 * (np.trace(rotation) - 1)) * 180 / np.pi}")
 
-    pts = (rotation.transpose() * pts.transpose()).transpose()
+    pts = (rotation.transpose() @ pts.transpose()).transpose()
     pts[np.abs(pts)<1e-15] = 0. # clipping points too close to zero
     logger.info(f"Un-rotated pts : {pts}")
 

--- a/geos-mesh/src/geos/mesh/processing/rotateAndTranslate.py
+++ b/geos-mesh/src/geos/mesh/processing/rotateAndTranslate.py
@@ -2,11 +2,11 @@ from vtkmodules.numpy_interface import dataset_adapter as dsa
 from vtkmodules.vtkCommonDataModel import vtkUnstructuredGrid
 from vtkmodules.vtkCommonTransforms import vtkTransform
 from vtkmodules.vtkFiltersGeneral import vtkTransformFilter
-from vtkmodules.vtkCommonCore import vtkPoints
 import numpy as np
 import logging
 
-def transform_mesh( input : vtkUnstructuredGrid, logger : logging.Logger | None = None ) -> vtkUnstructuredGrid:
+
+def transform_mesh( input: vtkUnstructuredGrid, logger: logging.Logger | None = None ) -> vtkUnstructuredGrid:
     """Apply a transformation to a mesh
 
     Args:
@@ -21,10 +21,11 @@ def transform_mesh( input : vtkUnstructuredGrid, logger : logging.Logger | None 
         logging.basicConfig( level=logging.WARNING )
         logger = logging.getLogger( __name__ )
 
-    translation, theta, axis = recenter_and_rotate( dsa.numpy_support.vtk_to_numpy(input.GetPoints().GetData()), logger )
+    translation, theta, axis = recenter_and_rotate( dsa.numpy_support.vtk_to_numpy( input.GetPoints().GetData() ),
+                                                    logger )
 
-    logger.info(f"Theta {theta}")
-    logger.info(f"Axis {axis}")
+    logger.info( f"Theta {theta}" )
+    logger.info( f"Axis {axis}" )
 
     # output = vtkUnstructuredGrid()
     # (vpts:= vtkPoints()).SetData( dsa.numpy_support.numpy_to_vtk(pts) )
@@ -32,80 +33,83 @@ def transform_mesh( input : vtkUnstructuredGrid, logger : logging.Logger | None 
     # output.SetCells(input.GetCellTypesArray(), input.GetCellLocationsArray(), input.GetCells())
 
     transform = vtkTransform()
-    transform.PostMultiply() # we want to apply rotation then translation
-    transform.RotateWXYZ(-theta, axis[0], axis[1], axis[2])
-    transform.Translate(-translation[0], -translation[1], -translation[2])
+    transform.PostMultiply()  # we want to apply rotation then translation
+    transform.RotateWXYZ( -theta, axis[ 0 ], axis[ 1 ], axis[ 2 ] )
+    transform.Translate( -translation[ 0 ], -translation[ 1 ], -translation[ 2 ] )
     transformFilter = vtkTransformFilter()
-    transformFilter.SetTransform(transform)
-    transformFilter.SetInputData(input)
+    transformFilter.SetTransform( transform )
+    transformFilter.SetInputData( input )
     transformFilter.Update()
 
     return transformFilter.GetOutput()
 
-def local_frame(pts):
+
+def local_frame( pts ):
     # find 3 orthogonal vectors
     # we assume points are on a box
     # first vector is along x axis
-    ori, _, _ = origin_bounding_box(pts)
-    assert ((ori == np.asarray([0, 0, 0])).all())
-    u = pts[1]
+    ori, _, _ = origin_bounding_box( pts )
+    assert ( ( ori == np.asarray( [ 0, 0, 0 ] ) ).all() )
+    u = pts[ 1 ]
     v = u
-    for pt in pts[2:]:# As we assume points are on a box there should be one orthogonal to u
-        if (np.abs(np.dot(u, pt)) < 0.0001):
+    for pt in pts[ 2: ]:  # As we assume points are on a box there should be one orthogonal to u
+        if ( np.abs( np.dot( u, pt ) ) < 0.0001 ):
             v = pt
             break
 
-    return (u, v, np.cross(u, v))
-    
+    return ( u, v, np.cross( u, v ) )
+
+
     # utils
-def origin_bounding_box( pts : np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """
-    Find the bounding box of a set of points
+def origin_bounding_box( pts: np.ndarray ) -> tuple[ np.ndarray, np.ndarray, np.ndarray ]:
+    """Find the bounding box of a set of points
     Args:
         pts (np.ndarray): points to find the bounding box of
     Returns:
         tuple[np.ndarray, np.ndarray, np.ndarray]: origin, min, max of the bounding box
     """
+    pt0 = pts[ np.argmin( pts, axis=0 ), : ]
+    pt1 = pts[ np.argmax( pts, axis=0 ), : ]
 
-    pt0 = pts[np.argmin(pts, axis=0), :]
-    pt1 = pts[np.argmax(pts, axis=0), :]
+    return ( pts[ 0 ], pt0, pt1 )
 
-    return (pts[0], pt0, pt1)
 
-def recenter_and_rotate(pts : np.ndarray, logger : logging.Logger) -> tuple[np.ndarray, float, np.ndarray]:
-    """
-    Recenter and rotate points to align with principal axes
+def recenter_and_rotate( pts: np.ndarray, logger: logging.Logger ) -> tuple[ np.ndarray, float, np.ndarray ]:
+    """Recenter and rotate points to align with principal axes
     
     Args:
         pts (np.ndarray): points to recenter and rotate
         logger (logging.logger, optional): logger instance.
     """
-
     # find bounding box
-    org, vmin, vmax = origin_bounding_box(pts)
-    logger.info(f"Bounding box is {org}, {vmin}, {vmax}")
+    org, vmin, vmax = origin_bounding_box( pts )
+    logger.info( f"Bounding box is {org}, {vmin}, {vmax}" )
 
     # Transformation
     translation = org
     pts -= translation
 
-    u, v, w = local_frame(pts)
-    logger.info(f"Local frame u {u}, v {v}, w {w}")
+    u, v, w = local_frame( pts )
+    logger.info( f"Local frame u {u}, v {v}, w {w}" )
 
     # find rotation R = U sig V
-    rotation = np.asarray([u / np.linalg.norm(u), v / np.linalg.norm(v), w / np.linalg.norm(w)],dtype=np.float64).transpose()
-    logger.info(f"R {rotation}")
+    rotation = np.asarray( [ u / np.linalg.norm( u ), v / np.linalg.norm( v ), w / np.linalg.norm( w ) ],
+                           dtype=np.float64 ).transpose()
+    logger.info( f"R {rotation}" )
 
-    theta = np.acos(.5 * (np.trace(rotation) - 1)) * 180 / np.pi
-    logger.info(f"theta {theta}")
+    theta = np.acos( .5 * ( np.trace( rotation ) - 1 ) ) * 180 / np.pi
+    logger.info( f"theta {theta}" )
 
-    axis = np.asarray([rotation[2, 1] - rotation[1, 2], rotation[0, 2] - rotation[2, 0], rotation[1, 0] - rotation[0, 1]],dtype=np.float64)
-    axis /= np.linalg.norm(axis)
-    logger.info(f"axis {axis}")
+    axis = np.asarray( [
+        rotation[ 2, 1 ] - rotation[ 1, 2 ], rotation[ 0, 2 ] - rotation[ 2, 0 ], rotation[ 1, 0 ] - rotation[ 0, 1 ]
+    ],
+                       dtype=np.float64 )
+    axis /= np.linalg.norm( axis )
+    logger.info( f"axis {axis}" )
 
-    pts = (rotation.transpose() @ pts.transpose()).transpose()
-    pts[np.abs(pts)<1e-15] = 0. # clipping points too close to zero
-    logger.info(f"Un-rotated pts : {pts}")
+    pts = ( rotation.transpose() @ pts.transpose() ).transpose()
+    pts[ np.abs( pts ) < 1e-15 ] = 0.  # clipping points too close to zero
+    logger.info( f"Un-rotated pts : {pts}" )
 
     # return translation, rotation, pts
     return translation, theta, axis
@@ -113,7 +117,7 @@ def recenter_and_rotate(pts : np.ndarray, logger : logging.Logger) -> tuple[np.n
 
 # #TO DO : remove
 # if __name__ == "__main__":
-    
+
 #     reader = vtk.vtkXMLUnstructuredGridReader()
 #     reader.SetFileName("/home/jfranc/codes/python/geosPythonPackages/geos-mesh/src/geos/mesh/processing/input.vtu")
 #     reader.Update()

--- a/geos-mesh/src/geos/mesh/processing/rotateAndTranslate.py
+++ b/geos-mesh/src/geos/mesh/processing/rotateAndTranslate.py
@@ -1,0 +1,111 @@
+from vtkmodules.numpy_interface import dataset_adapter as dsa
+from vtkmodules.vtkCommonDataModel import vtkUnstructuredGrid
+from vtkmodules.vtkCommonCore import vtkPoints
+import numpy as np
+import logging
+
+def transform_mesh( input : vtkUnstructuredGrid, logger : logging.Logger | None = None ) -> vtkUnstructuredGrid:
+    """Apply a transformation to a mesh
+
+    Args:
+        input (vtk.vtkUnstructuredGrid): input mesh
+        logger (logging.logger | None, optional): logger instance. Defaults to None.
+
+    Returns:
+        vtk.vtkUnstructuredGrid: transformed mesh
+    """
+    # Initialize the logger if it is empty
+    if not logger:
+        logging.basicConfig( level=logging.WARNING )
+        logger = logging.getLogger( __name__ )
+
+    translation, rotation, pts = recenter_and_rotate( dsa.numpy_support.vtk_to_numpy(input.GetPoints().GetData()), logger )
+
+    logger.info(f"Translation {translation}")
+    logger.info(f"Rotation {rotation}")
+
+    output = vtkUnstructuredGrid()
+    (vpts:= vtkPoints()).SetData( dsa.numpy_support.numpy_to_vtk(pts) )
+    output.SetPoints(vpts)
+    output.SetCells(input.GetCellTypesArray(), input.GetCellLocationsArray(), input.GetCells())
+
+    return output
+
+def local_frame(pts):
+    # find 3 orthogonal vectors
+    # we assume points are on a box
+    # first vector is along x axis
+    ori, _, _ = origin_bounding_box(pts)
+    assert ((ori == np.asarray([0, 0, 0])).all())
+    u = pts[1]
+    v = u
+    for pt in pts[2:]:# As we assume points are on a box there should be one orthogonal to u
+        if (np.abs(np.dot(u, pt)) < 0.0001):
+            v = pt
+            break
+
+    return (u, v, np.cross(u, v))
+    
+    # utils
+def origin_bounding_box( pts : np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Find the bounding box of a set of points
+    Args:
+        pts (np.ndarray): points to find the bounding box of
+    Returns:
+        tuple[np.ndarray, np.ndarray, np.ndarray]: origin, min, max of the bounding box
+    """
+
+    pt0 = pts[np.argmin(pts, axis=0), :]
+    pt1 = pts[np.argmax(pts, axis=0), :]
+
+    return (pts[0], pt0, pt1)
+
+def recenter_and_rotate(pts : np.ndarray, logger : logging.Logger) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Recenter and rotate points to align with principal axes
+    
+    Args:
+        pts (np.ndarray): points to recenter and rotate
+        logger (logging.logger, optional): logger instance.
+    """
+
+    # find bounding box
+    org, vmin, vmax = origin_bounding_box(pts)
+    logger.info(f"Bounding box is {org}, {vmin}, {vmax}")
+
+    # Transformation
+    translation = org
+    pts -= translation
+
+    u, v, w = local_frame(pts)
+    logger.info(f"Local frame u {u}, v {v}, w {w}")
+
+    # find rotation R = U sig V
+    rotation = np.matrix([u / np.linalg.norm(u), v / np.linalg.norm(v), w / np.linalg.norm(w)]).transpose()
+    logger.info(f"R {rotation}")
+    logger.info(f"theta {np.acos(.5 * (np.trace(rotation) - 1)) * 180 / np.pi}")
+
+    pts = (rotation.transpose() * pts.transpose()).transpose()
+    pts[np.abs(pts)<1e-15] = 0. # clipping points too close to zero
+    logger.info(f"Un-rotated pts : {pts}")
+
+    return translation, rotation, pts
+
+
+# #TO DO : remove
+# if __name__ == "__main__":
+    
+#     reader = vtk.vtkXMLUnstructuredGridReader()
+#     reader.SetFileName("/home/jfranc/codes/python/geosPythonPackages/geos-mesh/src/geos/mesh/processing/input.vtu")
+#     reader.Update()
+
+#     # Transformation
+#     output = transform_mesh(reader.GetOutput())
+
+#     output.SetCells(VTK_HEXAHEDRON, reader.GetOutput().GetCells())
+#     writer = vtk.vtkXMLUnstructuredGridWriter()
+#     writer.SetFileName("./output.vtu")
+#     writer.SetInputData(output)
+#     writer.Update()
+#     writer.Write()

--- a/geos-mesh/tests/test_rotateAndTranslate.py
+++ b/geos-mesh/tests/test_rotateAndTranslate.py
@@ -3,91 +3,99 @@ from dataclasses import dataclass
 from typing import Generator
 from vtkmodules.vtkCommonCore import vtkIdList, vtkPoints
 from vtkmodules.vtkCommonDataModel import vtkUnstructuredGrid, vtkHexahedron, VTK_HEXAHEDRON
-from vtkmodules.vtkIOXML import vtkXMLUnstructuredGridWriter # for writing the output tmp
-import logging # for debug
+import logging  # for debug
 from vtkmodules.numpy_interface import dataset_adapter as dsa
 import numpy as np
 from vtkmodules.util.vtkConstants import VTK_HEXAHEDRON
 
 from geos.mesh.processing.rotateAndTranslate import transform_mesh
 
+
 @dataclass( frozen=True )
 class Expected:
     mesh: vtkUnstructuredGrid
 
-def __gen_box(Lx:int, Ly:int, Lz:int, nx:int, ny:int, nz:int)-> tuple[np.ndarray, np.ndarray]:
+
+def __gen_box( Lx: int, Ly: int, Lz: int, nx: int, ny: int, nz: int ) -> tuple[ np.ndarray, np.ndarray ]:
     # np.random.seed(1) # for reproducibility
     np.random.default_rng()
-    off = np.random.randn(1, 3)
+    off = np.random.randn( 1, 3 )
     pts = []
-    x,y,z = np.meshgrid(np.linspace(0,Lx,nx),np.linspace(0,Ly,ny),np.linspace(0,Lz,ny))
-    for i in range(x.shape[0]):
-        for j in range(x.shape[1]):
-            for k in range(x.shape[2]):
-                pts.append(np.asarray([x[i,j,k], y[i,j,k], z[i,j,k]]))
+    x, y, z = np.meshgrid( np.linspace( 0, Lx, nx ), np.linspace( 0, Ly, ny ), np.linspace( 0, Lz, ny ) )
+    for i in range( x.shape[ 0 ] ):
+        for j in range( x.shape[ 1 ] ):
+            for k in range( x.shape[ 2 ] ):
+                pts.append( np.asarray( [ x[ i, j, k ], y[ i, j, k ], z[ i, j, k ] ] ) )
 
-    return (np.asarray(pts), off)
+    return ( np.asarray( pts ), off )
 
-def __rotate_box(angles : np.ndarray, pts:np.ndarray) -> np.ndarray:
-    a = angles[0]
-    RX = np.asarray([[1., 0, 0], [0, np.cos(a), -np.sin(a)], [0, np.sin(a), np.cos(a)]])
-    a = angles[1]
-    RY = np.asarray([[np.cos(a), 0, np.sin(a)], [0, 1, 0], [-np.sin(a), 0, np.cos(a)]])
-    a = angles[2]
-    RZ = np.asarray([[np.cos(a), -np.sin(a), 0], [np.sin(a), np.cos(a), 0], [0, 0, 1]])
 
-    return np.asarray((RZ @ RY @ RX @ pts.transpose()).transpose())
+def __rotate_box( angles: np.ndarray, pts: np.ndarray ) -> np.ndarray:
+    a = angles[ 0 ]
+    RX = np.asarray( [ [ 1., 0, 0 ], [ 0, np.cos( a ), -np.sin( a ) ], [ 0, np.sin( a ), np.cos( a ) ] ] )
+    a = angles[ 1 ]
+    RY = np.asarray( [ [ np.cos( a ), 0, np.sin( a ) ], [ 0, 1, 0 ], [ -np.sin( a ), 0, np.cos( a ) ] ] )
+    a = angles[ 2 ]
+    RZ = np.asarray( [ [ np.cos( a ), -np.sin( a ), 0 ], [ np.sin( a ), np.cos( a ), 0 ], [ 0, 0, 1 ] ] )
+
+    return np.asarray( ( RZ @ RY @ RX @ pts.transpose() ).transpose() )
+
 
 def __build_test_mesh() -> Generator[ Expected, None, None ]:
     # generate random points in a box Lx, Ly, Lz
     # np.random.seed(1) # for reproducibility
     np.random.default_rng()
-    Lx, Ly, Lz = (2, 5, 8) # box size
-    nx, ny, nz = (10, 10, 10) # number of points in each direction
-    pts, off = __gen_box(Lx, Ly, Lz, nx, ny, nz)
+    Lx, Ly, Lz = ( 2, 5, 8 )  # box size
+    nx, ny, nz = ( 10, 10, 10 )  # number of points in each direction
+    pts, off = __gen_box( Lx, Ly, Lz, nx, ny, nz )
 
-    logging.warning(f"Offseting of {off}")
-    logging.warning(f"Original pts : {pts}")
-    angles = -2*np.pi + np.random.randn(1, 3)*np.pi # random angles in rad
-    logging.warning(f"angles {angles[0]}")
-    pts = __rotate_box(angles[0], pts)
-    logging.info(f"Rotated pts : {pts}")
-    pts[:, 0] += off[0][0]
-    pts[:, 1] += off[0][1]
-    pts[:, 2] += off[0][2]
-    logging.info(f"Translated pts : {pts}")
+    logging.warning( f"Offseting of {off}" )
+    logging.warning( f"Original pts : {pts}" )
+    angles = -2 * np.pi + np.random.randn( 1, 3 ) * np.pi  # random angles in rad
+    logging.warning( f"angles {angles[0]}" )
+    pts = __rotate_box( angles[ 0 ], pts )
+    logging.info( f"Rotated pts : {pts}" )
+    pts[ :, 0 ] += off[ 0 ][ 0 ]
+    pts[ :, 1 ] += off[ 0 ][ 1 ]
+    pts[ :, 2 ] += off[ 0 ][ 2 ]
+    logging.info( f"Translated pts : {pts}" )
 
     # Creating multiple meshes, each time with a different angles
     mesh = vtkUnstructuredGrid()
-    (vtps:=vtkPoints()).SetData( dsa.numpy_support.numpy_to_vtk(pts) )
+    ( vtps := vtkPoints() ).SetData( dsa.numpy_support.numpy_to_vtk( pts ) )
     mesh.SetPoints( vtps )
 
     ids = vtkIdList()
-    for i in range(nx-1):
-        for j in range(ny-1):
-            for k in range(nz-1):
+    for i in range( nx - 1 ):
+        for j in range( ny - 1 ):
+            for k in range( nz - 1 ):
                 hex = vtkHexahedron()
                 ids = hex.GetPointIds()
-                ids.SetId(0,i+j*nx+k*nx*ny)
-                ids.SetId(1,i+j*nx+k*nx*ny + 1)
-                ids.SetId(2,i+j*nx+k*nx*ny + nx*ny+1)
-                ids.SetId(3,i+j*nx+k*nx*ny + nx*ny)
-                ids.SetId(4,i+j*nx+k*nx*ny + nx)
-                ids.SetId(5,i+j*nx+k*nx*ny + nx+1)
-                ids.SetId(6,i+j*nx+k*nx*ny + nx*ny+nx+1)
-                ids.SetId(7,i+j*nx+k*nx*ny + nx*ny+nx)
-                mesh.InsertNextCell(VTK_HEXAHEDRON,ids)
+                ids.SetId( 0, i + j * nx + k * nx * ny )
+                ids.SetId( 1, i + j * nx + k * nx * ny + 1 )
+                ids.SetId( 2, i + j * nx + k * nx * ny + nx * ny + 1 )
+                ids.SetId( 3, i + j * nx + k * nx * ny + nx * ny )
+                ids.SetId( 4, i + j * nx + k * nx * ny + nx )
+                ids.SetId( 5, i + j * nx + k * nx * ny + nx + 1 )
+                ids.SetId( 6, i + j * nx + k * nx * ny + nx * ny + nx + 1 )
+                ids.SetId( 7, i + j * nx + k * nx * ny + nx * ny + nx )
+                mesh.InsertNextCell( VTK_HEXAHEDRON, ids )
 
-    yield Expected( mesh=mesh ) 
+    yield Expected( mesh=mesh )
+
 
 @pytest.mark.parametrize( "expected", __build_test_mesh() )
 def test_rotateAndTranslate_polyhedron( expected: Expected ) -> None:
     output_mesh = transform_mesh( expected.mesh )
     assert output_mesh.GetNumberOfPoints() == expected.mesh.GetNumberOfPoints()
     assert output_mesh.GetNumberOfCells() == expected.mesh.GetNumberOfCells()
-    assert output_mesh.GetBounds()[0] == pytest.approx(0., abs=1e-10) and output_mesh.GetBounds()[2] == pytest.approx(0., abs=1e-10) and output_mesh.GetBounds()[4] == pytest.approx(0., abs=1e-10)
+    assert output_mesh.GetBounds()[ 0 ] == pytest.approx(
+        0., abs=1e-10 ) and output_mesh.GetBounds()[ 2 ] == pytest.approx(
+            0., abs=1e-10 ) and output_mesh.GetBounds()[ 4 ] == pytest.approx( 0., abs=1e-10 )
     #TODO more assert but need more assumptions then
     # temp
+
+
 #     w = vtkXMLUnstructuredGridWriter()
 #     w.SetFileName("./test_rotateAndTranslate.vtu")
 #     w.SetInputData(output_mesh)

--- a/geos-mesh/tests/test_rotateAndTranslate.py
+++ b/geos-mesh/tests/test_rotateAndTranslate.py
@@ -1,0 +1,98 @@
+import pytest
+from dataclasses import dataclass
+from typing import Generator
+from vtkmodules.vtkCommonCore import vtkIdList, vtkPoints
+from vtkmodules.vtkCommonDataModel import vtkUnstructuredGrid, vtkHexahedron, VTK_HEXAHEDRON
+from vtkmodules.vtkIOXML import vtkXMLUnstructuredGridWriter # for writing the output tmp
+from vtkmodules.numpy_interface import dataset_adapter as dsa
+import numpy as np
+from vtkmodules.util.vtkConstants import VTK_HEXAHEDRON
+
+from geos.mesh.processing.rotateAndTranslate import transform_mesh
+
+@dataclass( frozen=True )
+class Expected:
+    mesh: vtkUnstructuredGrid
+
+def __gen_box(Lx:int, Ly:int, Lz:int, nx:int, ny:int, nz:int)-> tuple[np.ndarray, np.ndarray]:
+    np.random.seed(1)
+    off = np.random.randn(1, 3)
+    pts = []
+    x,y,z = np.meshgrid(np.linspace(0,Lx,nx),np.linspace(0,Ly,ny),np.linspace(0,Lz,ny))
+    for i in range(x.shape[0]):
+        for j in range(x.shape[1]):
+            for k in range(x.shape[2]):
+                pts.append(np.asarray([x[i,j,k], y[i,j,k], z[i,j,k]]))
+
+    return (np.asarray(pts), off)
+
+def __rotate_box(angles : np.ndarray, pts:np.ndarray) -> np.ndarray:
+    a = angles[0]
+    RX = np.matrix([[1., 0, 0], [0, np.cos(a), -np.sin(a)], [0, np.sin(a), np.cos(a)]])
+    a = angles[1]
+    RY = np.matrix([[np.cos(a), 0, np.sin(a)], [0, 1, 0], [-np.sin(a), 0, np.cos(a)]])
+    a = angles[2]
+    RZ = np.matrix([[np.cos(a), -np.sin(a), 0], [np.sin(a), np.cos(a), 0], [0, 0, 1]])
+
+    return np.asarray((RZ * RY * RX * pts.transpose()).transpose())
+
+def __build_test_mesh() -> Generator[ Expected, None, None ]:
+    # generate random points in a box Lx, Ly, Lz
+    np.random.seed(1)
+    Lx, Ly, Lz = (2, 5, 8) # box size
+    nx, ny, nz = (10, 10, 10) # number of points in each direction
+    pts, off = __gen_box(Lx, Ly, Lz, nx, ny, nz)
+
+    print(f"Offseting of {off}")
+    print(f"Original pts : {pts}")
+    angles = -2*np.pi + np.random.randn(1, 3)*np.pi # random angles in rad
+    print(f"angles {angles[0]}")
+    pts = __rotate_box(angles[0], pts)
+    print(f"Rotated pts : {pts}")
+    pts[:, 0] += off[0][0]
+    pts[:, 1] += off[0][1]
+    pts[:, 2] += off[0][2]
+    print(f"Translated pts : {pts}")
+
+    # Creating multiple meshes, each time with a different angles
+    mesh = vtkUnstructuredGrid()
+    (vtps:=vtkPoints()).SetData( dsa.numpy_support.numpy_to_vtk(pts) )
+    mesh.SetPoints( vtps )
+
+    ids = vtkIdList()
+    for i in range(nx-1):
+        for j in range(ny-1):
+            for k in range(nz-1):
+                hex = vtkHexahedron()
+                ids = hex.GetPointIds()
+                ids.SetId(0,i+j*nx+k*nx*ny)
+                ids.SetId(1,i+j*nx+k*nx*ny + 1)
+                ids.SetId(2,i+j*nx+k*nx*ny + nx*ny+1)
+                ids.SetId(3,i+j*nx+k*nx*ny + nx*ny)
+                ids.SetId(4,i+j*nx+k*nx*ny + nx)
+                ids.SetId(5,i+j*nx+k*nx*ny + nx+1)
+                ids.SetId(6,i+j*nx+k*nx*ny + nx*ny+nx+1)
+                ids.SetId(7,i+j*nx+k*nx*ny + nx*ny+nx)
+                mesh.InsertNextCell(VTK_HEXAHEDRON,ids)
+
+    yield Expected( mesh=mesh ) 
+
+@pytest.mark.parametrize( "expected", __build_test_mesh() )
+def test_reorient_polyhedron( expected: Expected ) -> None:
+    output_mesh = transform_mesh( expected.mesh )
+    assert output_mesh.GetNumberOfPoints() == expected.mesh.GetNumberOfPoints()
+    assert output_mesh.GetNumberOfCells() == expected.mesh.GetNumberOfCells()
+    print(f"Bounds {output_mesh.GetBounds()}")
+    assert output_mesh.GetBounds()[0] == pytest.approx(0., abs=1e-10) and output_mesh.GetBounds()[2] == pytest.approx(0., abs=1e-10) and output_mesh.GetBounds()[4] == pytest.approx(0., abs=1e-10)
+    #TODO more assert but need more assumptions then
+    # temp
+    w = vtkXMLUnstructuredGridWriter()
+    w.SetFileName("./test_rotateAndTranslate.vtk")
+    w.SetInputData(output_mesh)
+    w.Write()
+    w.SetFileName("./test_rotateAndTranslate_input.vtk")
+    w.SetInputData(expected.mesh)
+    w.Write()
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/geos-mesh/tests/test_rotateAndTranslate.py
+++ b/geos-mesh/tests/test_rotateAndTranslate.py
@@ -93,7 +93,18 @@ def test_rotateAndTranslate_polyhedron( expected: Expected ) -> None:
         0., abs=1e-10 ) and output_mesh.GetBounds()[ 2 ] == pytest.approx(
             0., abs=1e-10 ) and output_mesh.GetBounds()[ 4 ] == pytest.approx( 0., abs=1e-10 )
     #TODO more assert but need more assumptions then
-    # temp
+    # test diagonal
+    assert np.linalg.norm( np.array( [ output_mesh.GetBounds()[ 1 ] - output_mesh.GetBounds()[ 0 ],
+                                      output_mesh.GetBounds()[ 3 ] - output_mesh.GetBounds()[ 2 ],
+                                      output_mesh.GetBounds()[ 5 ] - output_mesh.GetBounds()[ 4 ] ] ) ) == pytest.approx(
+                                          np.linalg.norm( np.array( [ 5, 8, 2 ] ) ), abs=1e-10 )
+    # test aligned with axis
+    v0 = np.array( output_mesh.GetPoint( 1 ) ) - np.array( output_mesh.GetPoint( 0 ) )
+    v1 = np.array( output_mesh.GetPoint( 10 ) ) - np.array( output_mesh.GetPoint( 0 ) )
+    v2 = np.array( output_mesh.GetPoint( 10 * 10 ) ) - np.array( output_mesh.GetPoint( 0 ) )
+    assert np.abs( np.dot( v0, v1 ) ) < 1e-10
+    assert np.abs( np.dot( v0, v2 ) ) < 1e-10
+    assert np.abs( np.dot( v1, v2 ) ) < 1e-10
 
 
 #     w = vtkXMLUnstructuredGridWriter()

--- a/geos-mesh/tests/test_rotateAndTranslate.py
+++ b/geos-mesh/tests/test_rotateAndTranslate.py
@@ -28,13 +28,13 @@ def __gen_box(Lx:int, Ly:int, Lz:int, nx:int, ny:int, nz:int)-> tuple[np.ndarray
 
 def __rotate_box(angles : np.ndarray, pts:np.ndarray) -> np.ndarray:
     a = angles[0]
-    RX = np.matrix([[1., 0, 0], [0, np.cos(a), -np.sin(a)], [0, np.sin(a), np.cos(a)]])
+    RX = np.asarray([[1., 0, 0], [0, np.cos(a), -np.sin(a)], [0, np.sin(a), np.cos(a)]])
     a = angles[1]
-    RY = np.matrix([[np.cos(a), 0, np.sin(a)], [0, 1, 0], [-np.sin(a), 0, np.cos(a)]])
+    RY = np.asarray([[np.cos(a), 0, np.sin(a)], [0, 1, 0], [-np.sin(a), 0, np.cos(a)]])
     a = angles[2]
-    RZ = np.matrix([[np.cos(a), -np.sin(a), 0], [np.sin(a), np.cos(a), 0], [0, 0, 1]])
+    RZ = np.asarray([[np.cos(a), -np.sin(a), 0], [np.sin(a), np.cos(a), 0], [0, 0, 1]])
 
-    return np.asarray((RZ * RY * RX * pts.transpose()).transpose())
+    return np.asarray((RZ @ RY @ RX @ pts.transpose()).transpose())
 
 def __build_test_mesh() -> Generator[ Expected, None, None ]:
     # generate random points in a box Lx, Ly, Lz


### PR DESCRIPTION
This PR introduces a new `rotateAndTranslate.py` modifiers that derive the translation and rotation a hexahedral domain has undergone and revert it so the mesh has one extermal vertices set to (0,0,0) and is aligned with (X,Y,Z)

This PR includes:

- `rotateAndTranslate.py` that introduces `recenter_and_rotate(...)` compute function for *theta* angle, v *axis* and t *translation*.  This is then wrapped in a `transform_mesh(...)` function that is leveraging `Transform` and  `TransformFilter` objects from vtk. This should ensure greater robustness.
- `test_rotateAndTranslate.py` that includes such hexahedral mesh randomly rotated and translated and test the above utlis. For now it is only checking that the mesh: 
   - did not change in number of cells and points
   - that the lowest bound is indeed (0,0,0)
   - that the domaine is not scaled by checking diagonal meas persistence
   - that it is align with (X,Y,Z)