### PR TITLE
fix: Clean verbosity in the function fillAllPartialAttributes

### DIFF
--- a/geos-mesh/src/geos/mesh/utils/arrayModifiers.py
+++ b/geos-mesh/src/geos/mesh/utils/arrayModifiers.py
@@ -176,8 +176,10 @@ def fillAllPartialAttributes(
     # Check if an external logger is given.
     if logger is None:
         logger = getLogger( "fillAllPartialAttributes", True )
-    
-    logger.warning( "The filling value for the attributes is depending of the type of attribute's data:\n0 for uint data,\n-1 for int data,\nnan for float data.")
+
+    logger.warning(
+        "The filling value for the attributes is depending of the type of attribute's data:\n0 for uint data,\n-1 for int data,\nnan for float data."
+    )
 
     # Parse all partial attributes, onPoints and onCells to fill them.
     for onPoints in [ True, False ]:

--- a/geos-mesh/src/geos/mesh/utils/arrayModifiers.py
+++ b/geos-mesh/src/geos/mesh/utils/arrayModifiers.py
@@ -60,6 +60,7 @@ def fillPartialAttributes(
     onPoints: bool = False,
     listValues: Union[ list[ Any ], None ] = None,
     logger: Union[ Logger, None ] = None,
+    fillAll: bool = False,
 ) -> bool:
     """Fill input partial attribute of multiBlockDataSet with a constant value per component.
 
@@ -75,6 +76,8 @@ def fillPartialAttributes(
             nan for float VTK arrays.
         logger (Union[Logger, None], optional): A logger to manage the output messages.
             Defaults to None, an internal logger is used.
+        fillAll (bool, optional): True if fillPartialAttributes is used by fillAllPartialAttributes, else False.
+            Defaults to False.
 
     Returns:
         bool: True if the attribute was correctly created and filled, False if not.
@@ -105,31 +108,28 @@ def fillPartialAttributes(
     # Set the default value depending of the type of the attribute to fill
     if listValues is None:
         defaultValue: Any
-        logger.warning( f"The attribute { attributeName } is filled with the default value for each component." )
+        mess: str = f"The attribute { attributeName } is filled with the default value for each component.\n"
         # Default value for float types is nan.
         if vtkDataType in ( VTK_FLOAT, VTK_DOUBLE ):
             defaultValue = valueType( np.nan )
-            logger.warning(
-                f"{ attributeName } vtk data type is { vtkDataType } corresponding to { defaultValue.dtype } numpy type, default value is automatically set to nan."
-            )
+            mess = mess + f"{ attributeName } vtk data type is { vtkDataType } corresponding to { defaultValue.dtype } numpy type, default value is automatically set to nan."
         # Default value for int types is -1.
         elif vtkDataType in ( VTK_CHAR, VTK_SIGNED_CHAR, VTK_SHORT, VTK_LONG, VTK_INT, VTK_LONG_LONG, VTK_ID_TYPE ):
             defaultValue = valueType( -1 )
-            logger.warning(
-                f"{ attributeName } vtk data type is { vtkDataType } corresponding to { defaultValue.dtype } numpy type, default value is automatically set to -1."
-            )
+            mess = mess + f"{ attributeName } vtk data type is { vtkDataType } corresponding to { defaultValue.dtype } numpy type, default value is automatically set to -1."
         # Default value for uint types is 0.
         elif vtkDataType in ( VTK_BIT, VTK_UNSIGNED_CHAR, VTK_UNSIGNED_SHORT, VTK_UNSIGNED_LONG, VTK_UNSIGNED_INT,
                               VTK_UNSIGNED_LONG_LONG ):
             defaultValue = valueType( 0 )
-            logger.warning(
-                f"{ attributeName } vtk data type is { vtkDataType } corresponding to { defaultValue.dtype } numpy type, default value is automatically set to 0."
-            )
+            mess = mess + f"{ attributeName } vtk data type is { vtkDataType } corresponding to { defaultValue.dtype } numpy type, default value is automatically set to 0."
         else:
             logger.error( f"The type of the attribute { attributeName } is not compatible with the function." )
             return False
 
         listValues = [ defaultValue ] * nbComponents
+
+        if not fillAll:
+            logger.warning( mess )
 
     else:
         if len( listValues ) != nbComponents:
@@ -158,7 +158,12 @@ def fillAllPartialAttributes(
     multiBlockDataSet: Union[ vtkMultiBlockDataSet, vtkCompositeDataSet, vtkDataObject ],
     logger: Union[ Logger, None ] = None,
 ) -> bool:
-    """Fill all partial attributes of a multiBlockDataSet with the default value. All components of each attributes are filled with the same value. Depending of the type of the attribute, the default value is different 0, -1 and nan for respectively uint, int and float vtk type.
+    """Fill all partial attributes of a multiBlockDataSet with the default value.
+
+    All components of each attributes are filled with the same value. Depending of the type of the attribute's data, the default value is different:
+        0 for uint data,
+        -1 for int data,
+        nan float data,
 
     Args:
         multiBlockDataSet (vtkMultiBlockDataSet | vtkCompositeDataSet | vtkDataObject): MultiBlockDataSet where to fill attributes.
@@ -171,13 +176,15 @@ def fillAllPartialAttributes(
     # Check if an external logger is given.
     if logger is None:
         logger = getLogger( "fillAllPartialAttributes", True )
+    
+    logger.warning( "The filling value for the attributes is depending of the type of attribute's data:\n0 for uint data,\n-1 for int data,\nnan for float data.")
 
     # Parse all partial attributes, onPoints and onCells to fill them.
     for onPoints in [ True, False ]:
         infoAttributes: dict[ str, int ] = getAttributesWithNumberOfComponents( multiBlockDataSet, onPoints )
         for attributeName in infoAttributes:
             if not isAttributeGlobal( multiBlockDataSet, attributeName, onPoints ) and \
-               not fillPartialAttributes( multiBlockDataSet, attributeName, onPoints=onPoints, logger=logger ):
+               not fillPartialAttributes( multiBlockDataSet, attributeName, onPoints=onPoints, logger=logger, fillAll=True ):
                 return False
 
     return True


### PR DESCRIPTION
This pr aims to contol the warning messages while using the function fillAllPartialAttributes.
Instead of having messages for all attribute filled, just one warning is log.