### PR TITLE
fix: Add missing dependency for `geos-posp` plugins init

### DIFF
--- a/geos-posp/pyproject.toml
+++ b/geos-posp/pyproject.toml
@@ -38,6 +38,7 @@ requires-python = ">= 3.10"
 dependencies = [
     "geos-geomechanics",
     "geos-utils",
+    "geos-mesh",
     "vtk >= 9.3",
     "numpy >= 2.2",
     "pandas >= 2.2",
@@ -56,11 +57,11 @@ build = [
   "build ~= 1.2"
 ]
 dev = [
-   "mypy", 
+   "mypy",
    "yapf",
 ]
 test = [
-   "pytest-cov", 
+   "pytest-cov",
    "pytest"
 ]
 

--- a/geos-posp/src/PVplugins/__init__.py
+++ b/geos-posp/src/PVplugins/__init__.py
@@ -5,7 +5,7 @@ import sys
 dir_path = os.path.dirname( os.path.realpath( __file__ ) )
 python_root = '../../..'
 
-python_modules = ( 'geos-posp', 'geos-utils', 'geos-geomechanics' )
+python_modules = ( 'geos-posp', 'geos-utils', 'geos-geomechanics', 'geos-mesh' )
 
 for m in python_modules:
     m_path = os.path.abspath( os.path.join( dir_path, python_root, m, 'src' ) )


### PR DESCRIPTION
This PR fixes the current load issue of Paraview plugins present in `geos-posp`.