### PR TITLE
feature: Adapt the plugins import to Paraview 6.0

### DIFF
--- a/geos-posp/src/geos_posp/visu/PVUtils/paraviewTreatments.py
+++ b/geos-posp/src/geos_posp/visu/PVUtils/paraviewTreatments.py
@@ -12,8 +12,16 @@ from geos.utils.GeosOutputsConstants import (
     ComponentNameEnum,
     GeosMeshOutputsEnum,
 )
-from paraview.modules.vtkPVVTKExtensionsMisc import (  # type: ignore[import-not-found]
-    vtkMergeBlocks, )
+from packaging.version import Version
+
+# TODO: remove this condition when all codes are adapted for Paraview 6.0
+import paraview
+if Version( paraview.__version__ ) >= Version( "6.0" ):
+    from vtkmodules.vtkFiltersParallel import vtkMergeBlocks
+else:
+    from paraview.modules.vtkPVVTKExtensionsMisc import (  # type: ignore[import-not-found]
+        vtkMergeBlocks, )
+
 from paraview.simple import (  # type: ignore[import-not-found]
     FindSource, GetActiveView, GetAnimationScene, GetDisplayProperties, GetSources, servermanager,
 )

--- a/geos-pv/src/geos/pv/utils/paraviewTreatments.py
+++ b/geos-pv/src/geos/pv/utils/paraviewTreatments.py
@@ -8,8 +8,16 @@ from typing import Any, Union
 import numpy as np
 import numpy.typing as npt
 import pandas as pd  # type: ignore[import-untyped]
-from paraview.modules.vtkPVVTKExtensionsMisc import (  # type: ignore[import-not-found]
-    vtkMergeBlocks, )
+
+from packaging.version import Version
+
+# TODO: remove this condition when all codes are adapted for Paraview 6.0
+import paraview
+if Version( paraview.__version__ ) >= Version( "6.0" ):
+    from vtkmodules.vtkFiltersParallel import vtkMergeBlocks
+else:
+    from paraview.modules.vtkPVVTKExtensionsMisc import (  # type: ignore[import-not-found]
+        vtkMergeBlocks, )
 from paraview.simple import (  # type: ignore[import-not-found]
     FindSource, GetActiveView, GetAnimationScene, GetDisplayProperties, GetSources, servermanager,
 )


### PR DESCRIPTION
This PR aims at fixing the Paraview plugins loading to the version 6.0. Some of the API paths have been modified and are causing import error. 

This work is part of the Issue #148 