### PR TITLE
fix: fix the plugin PVAttributeMapping

### DIFF
--- a/geos-pv/src/geos/pv/plugins/PVAttributeMapping.py
+++ b/geos-pv/src/geos/pv/plugins/PVAttributeMapping.py
@@ -114,7 +114,7 @@ class PVAttributeMapping( VTKPythonAlgorithmBase ):
                          input_domain_name="onPiece_Attribute_List">
             <RequiredProperties>
                 <Property function="Input" name="meshFrom" />
-                <Property function="FieldDataSelection" name="AttributeType" />
+                <Property function="FieldDataSelection" name="AttributePiece" />
             </RequiredProperties>
         </ArrayListDomain>
         <Documentation>


### PR DESCRIPTION
This pr aims to fix a bug in the paraview plugin PVAttributeMapping.
A change of a property name during the refactor (pr #128 commit b2cbc5e50520dd37e0b0920e0e9bb1d66012e641)  has been forgottent and leads to issue in paraview.