### PR TITLE
ci: Adding on-flag GEOS-CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,8 +33,10 @@ jobs:
         run: |
           echo "This is not a Pull-Request, skipping"
 
+  # build and test the standalone CI
   build:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -88,7 +90,6 @@ jobs:
 
         echo "Installing main package..."
         python -m pip install ./${{ matrix.package-name }}/[test]
-
     - name: Lint with yapf
       # working-directory: ./${{ matrix.package-name }}
       run: |


### PR DESCRIPTION
In order to avoid long CI build when work-in-progress, 

- [x] discard CI launch if semantics is ok but PR in draft mode
- [x] skip the GEOS-integration CI even if required as long as the flag 'test-geos-ci' is not set