### PR TITLE
fix: Invalid label checking in CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  LABEL_TEST_GEOS_INTEGRATION: 'test-geos-integration'
+  LABEL_FORCE_GEOS_INTEGRATION: 'force-geos-integration'
 
 jobs:
   # Checks if PR title follows conventional semantics
@@ -124,16 +127,16 @@ jobs:
     outputs:
       has_geos_integration_label: ${{ steps.set-label.outputs.has_label }}
     steps:
-      - name: Check if PR has 'test-geos-integration' label
+      - name: Check if PR has '${{ env.LABEL_TEST_GEOS_INTEGRATION }}' label
         id: set-label
         run: |
           echo "Checking for label..."
           LABEL_FOUND=false
           LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
           echo "PR Labels: $LABELS"
-          if echo "$LABELS" | grep -q "test-geos-integration"; then
+          if echo "$LABELS" | grep -q "${{ env.LABEL_TEST_GEOS_INTEGRATION }}"; then
             LABEL_FOUND=true
-            echo "Label 'test-geos-integration' found"
+            echo "Label '${{ env.LABEL_TEST_GEOS_INTEGRATION }}' found"
           fi
           echo "has_label=$LABEL_FOUND" >> $GITHUB_OUTPUT
   
@@ -143,16 +146,16 @@ jobs:
     outputs:
       has_geos_integration_force_label: ${{ steps.set-label.outputs.has_label }}
     steps:
-      - name: Check if PR has 'force-geos-integration' label
+      - name: Check if PR has '${{ env.LABEL_FORCE_GEOS_INTEGRATION }}' label
         id: set-label
         run: |
           echo "Checking for label..."
           LABEL_FOUND=false
           LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
           echo "PR Labels: $LABELS"
-          if echo "$LABELS" | grep -q "force-geos-integration"; then
+          if echo "$LABELS" | grep -q "${{ env.LABEL_FORCE_GEOS_INTEGRATION }}"; then
             LABEL_FOUND=true
-            echo "Label 'force-geos-integration' found"
+            echo "Label '${{ env.LABEL_FORCE_GEOS_INTEGRATION }}' found"
           fi
           echo "has_label=$LABEL_FOUND" >> $GITHUB_OUTPUT
 
@@ -262,7 +265,7 @@ jobs:
         else
           echo "⊘ GEOS integration test NOT required"
           echo "  All changes are in documentation, non-integrated packages, or config files"
-          echo "  To force GEOS integration testing, add the 'test-geos-integration' label"
+          echo "  To force GEOS integration testing, add the '${{ env.LABEL_TEST_GEOS_INTEGRATION }}' label"
           echo "required=false" >> "$GITHUB_OUTPUT"
           echo "skip_reason=no-geos-integrated-changes" >> "$GITHUB_OUTPUT"
         fi
@@ -289,20 +292,20 @@ jobs:
           
           echo "=== GEOS Integration Dispatch ==="
           echo "GEOS Required (by file changes): ${GEOS_REQUIRED}"
-          echo "Has 'test-geos-integration' label: ${HAS_TEST_LABEL}"
-          echo "Has 'force-geos-integration' label: ${HAS_FORCE_LABEL}"
+          echo "Has '${{ env.LABEL_TEST_GEOS_INTEGRATION }}' label: ${HAS_TEST_LABEL}"
+          echo "Has '${{ env.LABEL_FORCE_GEOS_INTEGRATION }}' label: ${HAS_FORCE_LABEL}"
           echo ""
           
           # Case 1: Force label - always run tests
           if [[ "$HAS_FORCE_LABEL" == "true" ]]; then
-            echo "✓ 'force-geos-integration' label present - forcing GEOS integration tests"
+            echo "✓ '${{ env.LABEL_FORCE_GEOS_INTEGRATION }}' label present - forcing GEOS integration tests"
             echo "skipped=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           
           # Case 2: GEOS required AND test label present - run tests
           if [[ "$GEOS_REQUIRED" == "true" && "$HAS_TEST_LABEL" == "true" ]]; then
-            echo "✓ GEOS integration required and 'test-geos-integration' label present"
+            echo "✓ GEOS integration required and '${{ env.LABEL_TEST_GEOS_INTEGRATION }}' label present"
             echo "  Will proceed with GEOS integration tests"
             echo "skipped=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -310,26 +313,26 @@ jobs:
           
           # Case 3: GEOS required BUT test label missing - ERROR
           if [[ "$GEOS_REQUIRED" == "true" && "$HAS_TEST_LABEL" == "false" ]]; then
-            echo "✗ ERROR: GEOS integration is required but 'test-geos-integration' label is missing"
+            echo "✗ ERROR: GEOS integration is required but '${{ env.LABEL_TEST_GEOS_INTEGRATION }}' label is missing"
             echo ""
             echo "Your PR modifies GEOS-integrated packages:"
             echo "  - geos-utils, geos-mesh, geos-xml-tools"
             echo "  - hdf5-wrapper, pygeos-tools, geos-ats"
             echo ""
-            echo "Action required: Add the 'test-geos-integration' label to this PR"
+            echo "Action required: Add the '${{ env.LABEL_TEST_GEOS_INTEGRATION }}' label to this PR"
             exit 1
           fi
           
           # Case 4: GEOS NOT required BUT test label present - SKIP TESTS
           if [[ "$GEOS_REQUIRED" == "false" && "$HAS_TEST_LABEL" == "true" ]]; then
-            echo "⊘ SKIPPED: 'test-geos-integration' label present but GEOS integration is not required"
+            echo "⊘ SKIPPED: '${{ env.LABEL_TEST_GEOS_INTEGRATION }}' label present but GEOS integration is not required"
             echo ""
             echo "Your changes only affect:"
             echo "  - Documentation"
             echo "  - Non-integrated packages"
             echo "  - Configuration files"
             echo ""
-            echo "If you want to run GEOS integration tests anyway, use 'force-geos-integration' label to explicitly force testing"
+            echo "If you want to run GEOS integration tests anyway, use '${{ env.LABEL_FORCE_GEOS_INTEGRATION }}' label to explicitly force testing"
             echo "skipped=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -390,7 +393,7 @@ jobs:
           echo "  - hdf5-wrapper, pygeos-tools, geos-ats"
           echo ""
           echo "If you want to run GEOS integration tests anyway,"
-          echo "add the 'test-geos-integration' label to this PR"
+          echo "add the '${{ env.LABEL_FORCE_GEOS_INTEGRATION }}' label to this PR"
           echo ""
           echo "✓ CI requirements satisfied - PR can be merged"
         fi


### PR DESCRIPTION
After looking at #142 actions, the "test-geos-integration" label used was not found when reaching the "geos_ci_dispatch" job.

**Two problems fixed:**

1. The old code tried to iterate over a JSON array as a string, which meant it only looped once with the entire JSON as a single item.
2. github.event.pull_request.labels returns an array of label objects with properties like name, color, id, etc even though we were only looking at names.

A small refactor to **use variables for the label names** was also added.