### PR TITLE
fix: Proxy logic in trame

### DIFF
--- a/geos-trame/src/geos/trame/app/deck/tree.py
+++ b/geos-trame/src/geos/trame/app/deck/tree.py
@@ -286,7 +286,7 @@ class DeckTree( object ):
 
             if proxy_name.isnumeric() and int( proxy_name ) < len( model_copy ):
                 models.append( ( proxy_name, model_copy ) )
-                model_copy = model_copy[ int(proxy_name) if is_list else proxy_name ]
+                model_copy = model_copy[ int( proxy_name ) if is_list else proxy_name ]
                 continue
 
             if proxy_name in model_copy:

--- a/geos-trame/src/geos/trame/app/ui/inspector.py
+++ b/geos-trame/src/geos/trame/app/ui/inspector.py
@@ -65,7 +65,7 @@ class DeckInspector( vuetify.VTreeview ):
                     proxy = self.simput_manager.proxymanager.get( obj_id )
                     #self.tree.decode( obj_id ) # if const function and return not used why ?? to decode context ??
                     for prop in proxy.edited_property_names:
-                        self.tree.update( obj_id, text.camel_case(prop), proxy.get_property( prop ) )
+                        self.tree.update( obj_id, text.camel_case( prop ), proxy.get_property( prop ) )
 
         self.simput_manager.proxymanager.on( _on_change )
 


### PR DESCRIPTION
Few fixes on trame to avoid crashes. The following behavior was not working:

- Change data in a A-node in the tree, select another B-node of the tree (so A-node changes are commited to the proxy) and then go back to to A-node toggling editor, the change should be visible in XML.
- Output to XML was crashing if edited (33f186d7b9493cc4a6c6f39b17790a65ab6cb982)
- Changes where not reflected in the new XML


