### PR TITLE
fix: collocated_nodes array name to match GEOS name

### DIFF
--- a/geos-mesh/src/geos/mesh/doctor/actions/checkFractures.py
+++ b/geos-mesh/src/geos/mesh/doctor/actions/checkFractures.py
@@ -52,7 +52,7 @@ def formatCollocatedNodes( fractureMesh: vtkUnstructuredGrid ) -> Sequence[ Iter
     Returns:
         Sequence[ Iterable[ int ] ]: An iterable over all the buckets of collocated nodes.
     """
-    collocatedNodes: numpy.ndarray = vtk_to_numpy( fractureMesh.GetPointData().GetArray( "collocatedNodes" ) )
+    collocatedNodes: numpy.ndarray = vtk_to_numpy( fractureMesh.GetPointData().GetArray( "collocated_nodes" ) )
     if len( collocatedNodes.shape ) == 1:
         collocatedNodes: numpy.ndarray = collocatedNodes.reshape( ( collocatedNodes.shape[ 0 ], 1 ) )
     generator = ( tuple( sorted( bucket[ bucket > -1 ] ) ) for bucket in collocatedNodes )

--- a/geos-mesh/src/geos/mesh/doctor/actions/generateFractures.py
+++ b/geos-mesh/src/geos/mesh/doctor/actions/generateFractures.py
@@ -521,7 +521,8 @@ def __generateFractureMesh( oldMesh: vtkUnstructuredGrid, fractureInfo: Fracture
         for j, val in enumerate( bucket ):
             collocatedNodes[ i, j ] = val
     array = numpy_to_vtk( collocatedNodes, array_type=VTK_ID_TYPE )
-    array.SetName( "collocatedNodes" )
+    array.SetName( "collocated_nodes" )  # Following the hardcoded naming convention used in GEOS for now:
+    # src/coreComponents/mesh/generators/CollocatedNodes.cpp:  string const COLLOCATED_NODES = "collocated_nodes";
 
     fractureMesh = vtkUnstructuredGrid()  # We could be using vtkPolyData, but it's not supported by GEOS for now.
     fractureMesh.SetPoints( points )

--- a/geos-mesh/tests/data/fracture_res5_id.vtp
+++ b/geos-mesh/tests/data/fracture_res5_id.vtp
@@ -3,7 +3,7 @@
   <PolyData>
     <Piece NumberOfPoints="212"                  NumberOfVerts="0"                    NumberOfLines="0"                    NumberOfStrips="0"                    NumberOfPolys="156"                 >
       <PointData GlobalIds="GLOBAL_IDS_POINTS">
-        <DataArray type="Int64" IdType="1" Name="collocatedNodes" NumberOfComponents="2" format="appended" RangeMin="3905.8931117"         RangeMax="5326.4624283"         offset="0"                   >
+        <DataArray type="Int64" IdType="1" Name="collocated_nodes" NumberOfComponents="2" format="appended" RangeMin="3905.8931117"         RangeMax="5326.4624283"         offset="0"                   >
           <InformationKey name="L2_NORM_RANGE" location="vtkDataArray" length="2">
             <Value index="0">
               3905.8931117

--- a/geos-mesh/tests/data/fracture_res5_id.vtu
+++ b/geos-mesh/tests/data/fracture_res5_id.vtu
@@ -3,7 +3,7 @@
   <UnstructuredGrid>
     <Piece NumberOfPoints="212" NumberOfCells="156">
       <PointData GlobalIds="GLOBAL_IDS_POINTS">
-        <DataArray type="Int64" IdType="1" Name="collocatedNodes" NumberOfComponents="2" format="binary" RangeMin="3905.8931116967346" RangeMax="5326.462428291407">
+        <DataArray type="Int64" IdType="1" Name="collocated_nodes" NumberOfComponents="2" format="binary" RangeMin="3905.8931116967346" RangeMax="5326.462428291407">
           AQAAAACAAABADQAABgMAAA==eJwtyMVSFgAAhVFduHDh+Ah2d2GD2I0NdnchJnZiYmCLgYmtKHZid3djgo0dG2f8z918c27B7Jn+LyVzoIX4BBfmk1yET3FRPs3F+AwX57N8Tkv4S+p5fym+wKX5IpfhS1yWL3M5vsJBfJWvaXl/Bb3ur8g3uBLf5Mp8i6vwba7KdziY7/I9DfFX0/v+UH7A1fkh1+BHXJMfcy1+wrX5KT/TOv66muqvx8+5Pr/gBvySG/IrbsSvuTG/4TQN8zfRdH9TfsvN+B035/fcgj9wS/7IrfgTf9Zwf4Rm+FvzF27DX7ktf+N2/J1nZgm0vX8Wd+BY7siddLa/M8/hudrFP4+7chx34/ncnRdwD17IPbmXLvL35sW8RPv4l3JfXsb9OJ7783IewCt4IEfqSv8gXsUJGuVfzYN5DQ/htTyU1/EwXs/DeYRu8EdzIm/Ukf5NPIo382jewmN4K4/lbTyOx+t2/wTewTt1oj+JJ/Eunsy7eQoncwzv4ak8Tff6p/M+3q8z/Ad4Jh/kWXyIY/kwz+YjPIfn6lH/PD7Gcdwya6DzuRUv4HCO0IX+1ryI2/BiXqJt/Uu5HS/j9hzPHXg5d+ROusLfmVdyF17FCdrVv5q78Rruzmu5B6/jntxL1/t78wbuw4m8Ufv6N3E/3sz9eQsP4K08kCN1m38Qb+co3sE7dbA/iYfwLh7Ku3kYJ/NwHqF7/NG8l0fyPt6vo/wHeDQf5DF8iMfyYR7H4/WIfwIf5Yl8jI/rJH8KT+YTPIVPcgyf4qk8TU/7p/MZPqs5sgWaU8/5c/F5vqC5/Xn0ov+S5vVf5nx8hfPzVS7ABfWavxBf5xta2F9Eb/pvaVH/bS7Gd7g43+USXFLv+UvxfX6gpf1l9KH/kZb1P+Zy/ISD+CmX5wr6zF+RU7kSP+fK/IJfahX/K67KrzmY33AIV9M0fyinc3V+yzX4Hb/Xmv4PXIs/cm3+xHW4rn721+MMrs9fuAF/5W/a0P+dG/EPbsw/OYyb6C9/U/7NzfgPN+e//A+qS/z/
           <InformationKey name="L2_NORM_RANGE" location="vtkDataArray" length="2">
             <Value index="0">

--- a/geos-mesh/tests/test_arrayHelpers.py
+++ b/geos-mesh/tests/test_arrayHelpers.py
@@ -70,7 +70,7 @@ def test_computeElementMapping(
 
 @pytest.mark.parametrize( "onpoints, expected", [ ( True, {
     'GLOBAL_IDS_POINTS': 1,
-    'collocatedNodes': 2,
+    'collocated_nodes': 2,
     'PointAttribute': 3
 } ), ( False, {
     'CELL_MARKERS': 1,
@@ -215,7 +215,7 @@ def test_getArrayInObject( request: pytest.FixtureRequest, arrayExpected: npt.ND
 @pytest.mark.parametrize( "attributeName, vtkDataType, onPoints", [
     ( "CellAttribute", 11, False ),
     ( "PointAttribute", 11, True ),
-    ( "collocatedNodes", 12, True ),
+    ( "collocated_nodes", 12, True ),
 ] )
 def test_getVtkArrayTypeInMultiBlock( dataSetTest: vtkMultiBlockDataSet, attributeName: str, vtkDataType: int,
                                       onPoints: bool ) -> None:
@@ -324,7 +324,7 @@ def test_getComponentNamesMultiBlock(
 
 
 @pytest.mark.parametrize( "attributeNames, onPoints, expected_columns", [
-    ( ( "collocatedNodes", ), True, ( "collocatedNodes_0", "collocatedNodes_1" ) ),
+    ( ( "collocated_nodes", ), True, ( "collocated_nodes_0", "collocated_nodes_1" ) ),
 ] )
 def test_getAttributeValuesAsDF( dataSetTest: vtkPolyData, attributeNames: Tuple[ str, ...], onPoints: bool,
                                  expected_columns: Tuple[ str, ...] ) -> None:

--- a/geos-mesh/tests/test_arrayModifiers.py
+++ b/geos-mesh/tests/test_arrayModifiers.py
@@ -58,12 +58,12 @@ from geos.mesh.utils import arrayModifiers
               np.nan ), np.float64( np.nan ), np.float64( np.nan ) ], VTK_DOUBLE ),
         # Test fill attributes with different number of component with or without component names.
         ( 3, "PORO", 1, (), False, None, [ np.float32( np.nan ) ], VTK_FLOAT ),
-        ( 1, "collocatedNodes", 2, ( None, None ), True, None, [ np.int64( -1 ), np.int64( -1 ) ], VTK_ID_TYPE ),
+        ( 1, "collocated_nodes", 2, ( None, None ), True, None, [ np.int64( -1 ), np.int64( -1 ) ], VTK_ID_TYPE ),
         # Test fill an attribute with different type of value.
         ( 3, "FAULT", 1, (), False, None, [ np.int32( -1 ) ], VTK_INT ),
         ( 3, "FAULT", 1, (), False, [ 4 ], [ np.int32( 4 ) ], VTK_INT ),
         ( 3, "PORO", 1, (), False, [ 4 ], [ np.float32( 4 ) ], VTK_FLOAT ),
-        ( 1, "collocatedNodes", 2, ( None, None ), True, [ 4, 4 ], [ np.int64( 4 ), np.int64( 4 ) ], VTK_ID_TYPE ),
+        ( 1, "collocated_nodes", 2, ( None, None ), True, [ 4, 4 ], [ np.int64( 4 ), np.int64( 4 ) ], VTK_ID_TYPE ),
         ( 3, "CellAttribute", 3, ( "AX1", "AX2", "AX3" ), False, [ 4, 4, 4 ],
           [ np.float64( 4 ), np.float64( 4 ), np.float64( 4 ) ], VTK_DOUBLE ),
     ] )
@@ -140,7 +140,7 @@ def test_FillAllPartialAttributes(
     for blockIndex in elementaryBlockIndexes:
         dataSet: vtkDataSet = vtkDataSet.SafeDownCast( multiBlockDataSetTest.GetDataSet( blockIndex ) )
         attributeExist: int
-        for attributeNameOnPoint in [ "PointAttribute", "collocatedNodes" ]:
+        for attributeNameOnPoint in [ "PointAttribute", "collocated_nodes" ]:
             attributeExist = dataSet.GetPointData().HasArray( attributeNameOnPoint )
             assert attributeExist == 1
         for attributeNameOnCell in [ "CELL_MARKERS", "CellAttribute", "FAULT", "PERM", "PORO" ]:
@@ -482,7 +482,7 @@ def test_copyAttributeDataSet(
 
 
 @pytest.mark.parametrize( "meshFromName, meshToName, attributeName, onPoints, defaultValueTest", [
-    ( "fracture", "emptyFracture", "collocatedNodes", True, [ -1, -1 ] ),
+    ( "fracture", "emptyFracture", "collocated_nodes", True, [ -1, -1 ] ),
     ( "multiblock", "emptyFracture", "FAULT", False, -1 ),
     ( "multiblock", "emptymultiblock", "FAULT", False, -1 ),
     ( "dataset", "emptymultiblock", "FAULT", False, -1 ),


### PR DESCRIPTION
When creating a split mesh using generateFractures, two meshes are created:
- a mesh with nodes split along fractures
- the fracture(s) mesh(es) associated with these fractures

The fracture meshes receive a new property called "collocated_nodes", which name is hardcoded in [CollocatedNodes.cpp](https://github.com/GEOS-DEV/GEOS/blob/889ea4e79768575b172d177ad4fa8ecd9449f6b1/src/coreComponents/mesh/generators/CollocatedNodes.cpp#L30).

Following the work done in #146 to update mesh-doctor to camelCase, the name was incorrectly changed to "collocatedNodes" which was a mistake and was noticed thanks to @bd713 and @jhuang2601 .

This PR aims to revert this change to keep the correct "collocated_nodes" name.