### PR TITLE
feat: Allow non-verbose XML in Trame

### DIFF
--- a/geos-trame/src/geos/trame/app/deck/tree.py
+++ b/geos-trame/src/geos/trame/app/deck/tree.py
@@ -118,7 +118,7 @@ class DeckTree( object ):
             attribute_name_generator=text.camel_case,
         )
 
-        config = SerializerConfig( indent="  ", xml_declaration=False )
+        config = SerializerConfig( indent="  ", xml_declaration=False, ignore_default_attributes=True )
         serializer = XmlSerializer( context=context, config=config )
 
         return format_xml( serializer.render( obj ) )


### PR DESCRIPTION
In trame, passing the `ignore_default_attributes` in the Serializer from Obhect to string allows to limit verbosity in the XML output both in-memory and written to file) 