### PR TITLE
fix: fix the load of geosPythonPackages dependencies

### DIFF
--- a/geos-pv/src/geos/pv/plugins/PVCreateConstantAttributePerRegion.py
+++ b/geos-pv/src/geos/pv/plugins/PVCreateConstantAttributePerRegion.py
@@ -24,6 +24,9 @@ from vtkmodules.vtkCommonDataModel import (
 # update sys.path to load all GEOS Python Package dependencies
 geos_pv_path: Path = Path( __file__ ).parent.parent.parent.parent.parent
 sys.path.insert( 0, str( geos_pv_path / "src" ) )
+from geos.pv.utils.config import update_paths
+
+update_paths()
 
 from geos.processing.generic_processing_tools.CreateConstantAttributePerRegion import CreateConstantAttributePerRegion
 

--- a/geos-pv/src/geos/pv/utils/details.py
+++ b/geos-pv/src/geos/pv/utils/details.py
@@ -3,8 +3,6 @@
 # SPDX-FileContributor: Martin Lemay, Romain Baville, Jacques Franc
 # ruff: noqa: E402 # disable Module level import not at top of file
 # mypy: disable-error-code="misc"
-import sys
-from pathlib import Path
 # Add Enum for filter categories
 from functools import update_wrapper
 from typing import Protocol, Any, Type, TypeVar, Callable, runtime_checkable, Union
@@ -24,13 +22,6 @@ from vtkmodules.vtkCommonCore import (
     vtkInformation,
     vtkInformationVector,
 )
-
-# update sys.path to load all GEOS Python Package dependencies
-geos_pv_path: Path = Path( __file__ ).parent.parent.parent.parent.parent
-sys.path.insert( 0, str( geos_pv_path / "src" ) )
-from geos.pv.utils.config import update_paths
-
-update_paths()
 
 __doc__ = """
 Set of decorators that allows quicker generation of DataSet derived to the same DataSet derived filters. If it a list of type is provided, then the unique output type is set to vtkDataObject.
@@ -59,6 +50,7 @@ class FilterCategory( str, Enum ):
 
 
 U = TypeVar( 'U', bound='vtkDataObject' )
+
 
 @runtime_checkable
 class IsSISOFilter( Protocol[ U ] ):


### PR DESCRIPTION
The update of the path to load the geosPythonPackages dependencies on ParaView for the plugin PVCreateConstantAttributePerRegion has been deleted by mistake in the pr #151. This pr aims to fix it.


This is a duplicate from PR #187 that had to be reverted due to a bug during the merge.