### PR TITLE
feat: Make opacity change on perf/box visible/hidden

### DIFF
--- a/geos-trame/src/geos/trame/app/ui/viewer/viewer.py
+++ b/geos-trame/src/geos/trame/app/ui/viewer/viewer.py
@@ -310,7 +310,7 @@ class DeckViewer( vuetify.VCard ):
         self._add_perforation( distance_from_head, path )
         self._make_mesh_transparent( True )
 
-    def _make_mesh_transparent( self, isTransparent: bool ):
+    def _make_mesh_transparent( self, isTransparent: bool ) -> None:
         opacity: float = 0.2 if isTransparent else 1.
         if self._mesh_actor is not None:
             prop = self._mesh_actor.GetProperty()


### PR DESCRIPTION
Based on first user feedback, this PR introduce transparency jump opacity going from 1.0 to 0.2 as soon as either box or well perforation are visible. And back to opaque if they are not