### PR TITLE
fix: Use correct precision from input mesh when generating fractures

### DIFF
--- a/mesh-doctor/src/geos/mesh_doctor/actions/generateFractures.py
+++ b/mesh-doctor/src/geos/mesh_doctor/actions/generateFractures.py
@@ -418,6 +418,7 @@ def __performSplit( oldMesh: vtkUnstructuredGrid, cellToNodeMapping: Mapping[ in
     # Creating the new points for the new mesh.
     oldPoints: vtkPoints = oldMesh.GetPoints()
     newPoints = vtkPoints()
+    newPoints.SetDataType( oldPoints.GetDataType() )  # Preserve precision from input mesh
     newPoints.SetNumberOfPoints( numNewPoints )
     collocatedNodes = ones( numNewPoints, dtype=int ) * -1
     # Copying old points into the new container.
@@ -528,6 +529,7 @@ def __generateFractureMesh( oldMesh: vtkUnstructuredGrid, fractureInfo: Fracture
     fractureNodes: Collection[ int ] = tuple( filter( lambda n: n > -1, fractureNodesTmp ) )
     numPoints: int = len( fractureNodes )
     points = vtkPoints()
+    points.SetDataType( meshPoints.GetDataType() )  # Preserve precision from input mesh
     points.SetNumberOfPoints( numPoints )
     node3dToNode2d: dict[ int, int ] = {}  # Building the node mapping, from 3d mesh nodes to 2d fracture nodes.
     for i, n in enumerate( fractureNodes ):


### PR DESCRIPTION
Currently when using _generateFractures_ feature from _mesh-doctor_, the **default precision for vtkPoints objects is float**.
This can become **an issue when the input mesh uses double precision** and we want to create a new instance of this input mesh with the split points to output.

In certain cases, it will mess up the node mapping from the input to the output mesh and we will get cells with invalid nodes ordering, therefore leading to invalid/zero/negative volumes.

This PR solves this issue by **checking the precision of points from the input mesh** and **applying this precision to the new vtkPoints objects** of the output mesh.

