### PR TITLE
fix: Fix filename change in PVTetQualityAnalysis plugin

### DIFF
--- a/geos-processing/src/geos/processing/pre_processing/TetQualityAnalysis.py
+++ b/geos-processing/src/geos/processing/pre_processing/TetQualityAnalysis.py
@@ -1147,7 +1147,8 @@ class TetQualityAnalysis:
         Args:
             filename (str): Output filename.
         """
-        self.filename = filename
+        if filename != "None":
+            self.filename = filename
 
     def __loggerSection( self: Self, sectionName: str ) -> None:
         self.logger.info( "=" * 80 )

--- a/geos-pv/src/geos/pv/plugins/qc/PVTetQualityAnalysis.py
+++ b/geos-pv/src/geos/pv/plugins/qc/PVTetQualityAnalysis.py
@@ -107,6 +107,7 @@ class PVTetQualityAnalysis( VTKPythonAlgorithmBase ):
             tetQualityAnalysisFilter.setLoggerHandler( VTKHandler() )
 
         try:
+            tetQualityAnalysisFilter.setFilename( self._filename )
             tetQualityAnalysisFilter.applyFilter()
         except Exception as e:
             tetQualityAnalysisFilter.logger.error( f' FATAL ERROR due to:\n{e}' )


### PR DESCRIPTION
When the user changed the filename in the ParaView interface, the output filename was not propagated to the filter. This PR fixes this behaviour.