### PR TITLE
fix: MeshDoctor: only keep faces in generateFracture where the matrix is actually split

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write  # for amannn/action-semantic-pull-request to analyze PRs and
       statuses: write  # for amannn/action-semantic-pull-request to mark status of analyzed PR
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check if the PR name has conventional semantics

--- a/mesh-doctor/src/geos/mesh_doctor/actions/generateFractures.py
+++ b/mesh-doctor/src/geos/mesh_doctor/actions/generateFractures.py
@@ -516,11 +516,8 @@ def __performSplit( oldMesh: vtkUnstructuredGrid, cellToNodeMapping: Mapping[ in
     return newMesh
 
 
-def __faceIsActuallySplit( oldMesh: vtkUnstructuredGrid,
-                           cellToNodeMapping: Mapping[ int, IDMapping ],
-                           ns: Collection[ int ],
-                           pointIdsList: vtkIdList,
-                           neighbors: vtkIdList ) -> bool:
+def __faceIsActuallySplit( oldMesh: vtkUnstructuredGrid, cellToNodeMapping: Mapping[ int, IDMapping ],
+                           ns: Collection[ int ], pointIdsList: vtkIdList, neighbors: vtkIdList ) -> bool:
     """Tells whether the matrix will actually be split along the face whose vertices are ``ns``.
 
     A candidate fracture face is a real fracture surface only if the split
@@ -547,8 +544,10 @@ def __faceIsActuallySplit( oldMesh: vtkUnstructuredGrid,
         pointIdsList.InsertNextId( n )
     neighbors.Reset()
     oldMesh.GetCellNeighbors( -1, pointIdsList, neighbors )
-    adjacentCells = [ neighbors.GetId( i ) for i in range( neighbors.GetNumberOfIds() )
-                      if oldMesh.GetCell( neighbors.GetId( i ) ).GetCellDimension() == 3 ]
+    adjacentCells = [
+        neighbors.GetId( i ) for i in range( neighbors.GetNumberOfIds() )
+        if oldMesh.GetCell( neighbors.GetId( i ) ).GetCellDimension() == 3
+    ]
     if len( adjacentCells ) < 2:
         # Boundary face with only one adjacent 3D cell => keep it.
         return True
@@ -682,8 +681,7 @@ def __splitMeshOnFractures( mesh: vtkUnstructuredGrid,
     outputMesh: vtkUnstructuredGrid = __performSplit( mesh, cellToNodeMapping )
     fractureMeshes: list[ vtkUnstructuredGrid ] = []
     for fractureInfoSeparated in allFractureInfos:
-        fractureMesh: vtkUnstructuredGrid = __generateFractureMesh( mesh, fractureInfoSeparated,
-                                                                    cellToNodeMapping )
+        fractureMesh: vtkUnstructuredGrid = __generateFractureMesh( mesh, fractureInfoSeparated, cellToNodeMapping )
         fractureMeshes.append( fractureMesh )
     return ( outputMesh, fractureMeshes )
 

--- a/mesh-doctor/src/geos/mesh_doctor/actions/generateFractures.py
+++ b/mesh-doctor/src/geos/mesh_doctor/actions/generateFractures.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright 2023-2024 TotalEnergies.
-# SPDX-FileContributor: Thomas Gazolla, Alexandre Benedicto
+# SPDX-FileContributor: Thomas Gazolla, Alexandre Benedicto, Bertrand Denel
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum

--- a/mesh-doctor/src/geos/mesh_doctor/actions/generateFractures.py
+++ b/mesh-doctor/src/geos/mesh_doctor/actions/generateFractures.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
 import networkx
-from numpy import empty, ones, zeros
+from numpy import empty, ones
 from tqdm import tqdm
 from typing import Collection, Iterable, Mapping, Optional, Sequence, TypeAlias
 from vtk import vtkDataArray
@@ -516,6 +516,50 @@ def __performSplit( oldMesh: vtkUnstructuredGrid, cellToNodeMapping: Mapping[ in
     return newMesh
 
 
+def __faceIsActuallySplit( oldMesh: vtkUnstructuredGrid,
+                           cellToNodeMapping: Mapping[ int, IDMapping ],
+                           ns: Collection[ int ],
+                           pointIdsList: vtkIdList,
+                           neighbors: vtkIdList ) -> bool:
+    """Tells whether the matrix will actually be split along the face whose vertices are ``ns``.
+
+    A candidate fracture face is a real fracture surface only if the split
+    algorithm ends up assigning *different* node copies to its two adjacent 3D
+    cells for at least one of its vertices. If every vertex resolves to the
+    same copy in both cells the matrix is not separated along this face.
+    This includes fully-tip faces (no node duplicated anywhere) and intersection
+    artifacts (duplication exists but is for another fracture, and both
+    adjacent cells fell on the same side of that other fracture).
+
+    Args:
+        oldMesh (vtkUnstructuredGrid): The input (pre-split) 3D mesh.
+        cellToNodeMapping (Mapping[ int, IDMapping ]): For each input cell, the per-vertex
+                                                       remap from original to split-time node ids.
+        ns (Collection[ int ]): The face's vertex ids in the original mesh.
+        pointIdsList (vtkIdList): Scratch buffer for the face's vertex ids (reused across calls).
+        neighbors (vtkIdList): Scratch buffer for the adjacent-cells query (reused across calls).
+
+    Returns:
+        bool: ``True`` if the face is a true fracture surface (kept), ``False`` if it should be discarded.
+    """
+    pointIdsList.Reset()
+    for n in ns:
+        pointIdsList.InsertNextId( n )
+    neighbors.Reset()
+    oldMesh.GetCellNeighbors( -1, pointIdsList, neighbors )
+    adjacentCells = [ neighbors.GetId( i ) for i in range( neighbors.GetNumberOfIds() )
+                      if oldMesh.GetCell( neighbors.GetId( i ) ).GetCellDimension() == 3 ]
+    if len( adjacentCells ) < 2:
+        # Boundary face with only one adjacent 3D cell => keep it.
+        return True
+    for n in ns:
+        copyA = cellToNodeMapping.get( adjacentCells[ 0 ], {} ).get( n, n )
+        copyB = cellToNodeMapping.get( adjacentCells[ 1 ], {} ).get( n, n )
+        if copyA != copyB:
+            return True
+    return False
+
+
 def __generateFractureMesh( oldMesh: vtkUnstructuredGrid, fractureInfo: FractureInfo,
                             cellToNodeMapping: Mapping[ int, IDMapping ] ) -> vtkUnstructuredGrid:
     """Generates the mesh of the fracture.
@@ -532,35 +576,33 @@ def __generateFractureMesh( oldMesh: vtkUnstructuredGrid, fractureInfo: Fracture
     setupLogger.info( "Generating the meshes" )
 
     meshPoints: vtkPoints = oldMesh.GetPoints()
-    isNodeDuplicated = zeros( meshPoints.GetNumberOfPoints(), dtype=bool )  # defaults to False
-    for nodeMapping in cellToNodeMapping.values():
-        for i, o in nodeMapping.items():
-            if not isNodeDuplicated[ i ]:
-                isNodeDuplicated[ i ] = i != o
 
-    # Some elements can have all their nodes not duplicated.
-    # In this case, it's mandatory not get rid of this element because the neighboring 3d elements won't follow.
+    # Filter out candidate faces that don't correspond to real fracture surfaces.
+    # See ``__faceIsActuallySplit`` for the criterion.
+    pointIdsList = vtkIdList()
+    neighbors = vtkIdList()
     faceNodes: list[ Collection[ int ] ] = []
     discardedFaceNodes: set[ Iterable[ int ] ] = set()
     if fractureInfo.faceCellId != []:  # The fracture policy is 'internalSurfaces'
         faceCellId: list[ int ] = []
         for ns, fId in zip( fractureInfo.faceNodes, fractureInfo.faceCellId ):
-            if any( map( isNodeDuplicated.__getitem__, ns ) ):
+            if __faceIsActuallySplit( oldMesh, cellToNodeMapping, ns, pointIdsList, neighbors ):
                 faceNodes.append( ns )
                 faceCellId.append( fId )
             else:
                 discardedFaceNodes.add( ns )
     else:  # The fracture policy is 'field'
         for ns in fractureInfo.faceNodes:
-            if any( map( isNodeDuplicated.__getitem__, ns ) ):
+            if __faceIsActuallySplit( oldMesh, cellToNodeMapping, ns, pointIdsList, neighbors ):
                 faceNodes.append( ns )
             else:
                 discardedFaceNodes.add( ns )
 
     if discardedFaceNodes:
         msg: str = "(" + '), ('.join( ", ".join( map( str, dfns ) ) for dfns in discardedFaceNodes ) + ")"
-        setupLogger.info( f"The faces made of nodes [{msg}] were/was discarded"
-                          " from the fracture mesh because none of their/its nodes were duplicated." )
+        setupLogger.info( f"The faces made of nodes [{msg}] were/was discarded from the fracture mesh"
+                          " because the matrix is not actually split along them"
+                          " (no node duplicated, or duplication is for another fracture)." )
 
     fractureNodesTmp = ones( meshPoints.GetNumberOfPoints(), dtype=int ) * -1
     for ns in faceNodes:
@@ -640,7 +682,8 @@ def __splitMeshOnFractures( mesh: vtkUnstructuredGrid,
     outputMesh: vtkUnstructuredGrid = __performSplit( mesh, cellToNodeMapping )
     fractureMeshes: list[ vtkUnstructuredGrid ] = []
     for fractureInfoSeparated in allFractureInfos:
-        fractureMesh: vtkUnstructuredGrid = __generateFractureMesh( mesh, fractureInfoSeparated, cellToNodeMapping )
+        fractureMesh: vtkUnstructuredGrid = __generateFractureMesh( mesh, fractureInfoSeparated,
+                                                                    cellToNodeMapping )
         fractureMeshes.append( fractureMesh )
     return ( outputMesh, fractureMeshes )
 


### PR DESCRIPTION
### Problem
When building fracture meshes, `__generateFractureMesh` does not remove from its list **ALL** faces that are located where the matrix is not actually split.
This leads to fault element with no opposite-side cell, which crashes GEOS downstream.

This can happen at fracture intersections (both adjacent cells land on the same side of another fracture's duplication) and fracture tips (no duplication at all on the face), see screenshot below.

### Fix
A candidate face is now kept only if the split algorithm assigns different node copies to the face's two adjacent 3D cells for at least one verte. If every vertex resolves to the same copy in both cells, the face is discarded.

### Illustration before/after for fracture tips
<img width="2346" height="1434" alt="image" src="https://github.com/user-attachments/assets/820b577d-58d5-4c9c-b376-fe38f45e7cd3" />
